### PR TITLE
Add ADR template

### DIFF
--- a/docusaurus/docs/decisions/0001-madr-architecture-decisions.md
+++ b/docusaurus/docs/decisions/0001-madr-architecture-decisions.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+sidebar_label: 0001 MADR Architecture Decisions
+# These are optional elements. Feel free to remove them if you don't need them.
+status: accepted
+date: 2024-04-12
+deciders: dhaval, chara
+consulted: patrick
+informed:
+---
+
+# Use Markdown Any Decision Records (MADR) to track Architectural Decisions
+
+## Context and Problem Statement
+
+As the Owner Community project evolves, maintaining architectural consistency becomes crucial. With a Node.js backend and a TypeScript React frontend, documenting and managing architectural decisions pose challenges. We must ensure alignment among team members and community contributors to avoid confusion and inconsistency. Therefore, an efficient framework is needed to document, evaluate, and communicate decisions, fostering transparency and collaboration.
+
+MADR is a lean template to capture any decisions in a structured way. The template originated from capturing architectural decisions and developed to a template allowing to capture any decisions taken.
+For more information [see](https://adr.github.io/)
+
+## Decision Drivers
+
+- **Consistency**: Ensure consistency in documenting architectural decisions.
+- **Transparency**: Architecture changes and associated decisions should be visible and accessible to the community.
+- **Discoverability**: Ensure that architectural decisions are easily discoverable and comprehensible by storing decision records in the repository for teams involved in various language ports.
+
+## Decision Outcome
+
+Chosen option: Use MADR format and store decision documents in the repository.
+
+## Pros and Cons of the Options
+
+### Use MADR format and store decision documents in the repository
+
+How would we use ADR's to track technical decisions?
+
+1. Copy docs/decisions/adr-template.md to docs/decisions/NNNN-title-with-dashes.md, where NNNN indicates the next number in sequence.
+   1. Check for existing PR's to make sure you use the correct sequence number.
+   2. There is also a short form template docs/decisions/adr-short-template.md
+2. Edit NNNN-title-with-dashes.md.
+   1. Status must initially be `proposed`
+   2. List of `deciders` must include the aliases of the people who will sign off on the decision.
+   3. The relevant EM and `patrick` must be listed as deciders or informed of all decisions.
+   4. You should list the aliases of all partners who were consulted as part of the decision.
+3. For each option list the good, neutral and bad aspects of each considered alternative.
+   1. Detailed investigations can be included in the `More Information` section inline or as links to external documents.
+4. Share your PR with the deciders and other interested parties.
+   1. Deciders must be listed as required reviewers.
+   2. The status must be updated to `accepted` once a decision is agreed and the date must also be updated.
+   3. Approval of the decision is captured using PR approval.
+5. Decisions can be changed later and superseded by a new ADR. In this case it is useful to record any negative outcomes in the original ADR.
+
+#### Pros:
+
+- Lightweight format: MADR provides a simple and easy-to-edit template for documenting architectural decisions.
+- Git review process: Utilizing the standard Git review process for commenting and approval ensures transparency and collaboration.
+- Community visibility: Decisions and the review process are transparent to the community, fostering openness and participation.
+
+#### Cons:
+
+- None identified.
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## More Information
+
+- Reference: [MADR](https://github.com/microsoft/semantic-kernel/blob/main/docs/decisions/0001-madr-architecture-decisions.md)

--- a/docusaurus/docs/decisions/adr-short-template.md
+++ b/docusaurus/docs/decisions/adr-short-template.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 6
+sidebar_label: ADR Short Template
+# These are optional elements. Feel free to remove any of them.
+status: proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-madr-architecture-decisions.md)
+contact: person proposing the ADR
+date: YYYY-MM-DD when the decision was last updated
+deciders: list everyone involved in the decision
+consulted: list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication
+informed: list everyone who is kept up-to-date on progress; and with whom there is a one-way communication
+---
+
+# short title of solved problem and solution
+
+## Context and Problem Statement
+
+Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Decision Drivers
+
+- decision driver 1, e.g., a force, facing concern, …
+- decision driver 2, e.g., a force, facing concern, …
+- … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+- title of option 1
+- title of option 2
+- title of option 3
+- … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "title of option 1", because
+justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force | … | comes out best (see below).

--- a/docusaurus/docs/decisions/adr-template.md
+++ b/docusaurus/docs/decisions/adr-template.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 5
+sidebar_label: ADR Template
+# These are optional elements. Feel free to remove any of them.
+status: proposed | rejected | accepted | deprecated | … | superseded by [ADR-0001](0001-madr-architecture-decisions.md)
+contact: person proposing the ADR
+date: YYYY-MM-DD when the decision was last updated
+deciders: list everyone involved in the decision
+consulted: list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication
+informed: list everyone who is kept up-to-date on progress; and with whom there is a one-way communication
+---
+
+# short title of solved problem and solution
+
+## Context and Problem Statement
+
+Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Decision Drivers
+
+- decision driver 1, e.g., a force, facing concern, …
+- decision driver 2, e.g., a force, facing concern, …
+- … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+- title of option 1
+- title of option 2
+- title of option 3
+- … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "title of option 1", because
+justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force | … | comes out best (see below).
+
+<!-- This is an optional element. Feel free to remove. -->
+
+### Consequences
+
+- Good, because positive consequence, e.g., improvement of one or more desired qualities, …
+- Bad, because negative consequence, e.g., compromising one or more desired qualities, …
+- … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Validation
+
+describe how the implementation of/compliance with the ADR is validated. E.g., by a review or an ArchUnit test
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## Pros and Cons of the Options
+
+### title of option 1
+
+<!-- This is an optional element. Feel free to remove. -->
+
+example | description | pointer to more information | …
+
+- Good, because argument a
+- Good, because argument b
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+- Neutral, because argument c
+- Bad, because argument d
+- … <!-- numbers of pros and cons can vary -->
+
+### title of other option
+
+example | description | pointer to more information | …
+
+- Good, because argument a
+- Good, because argument b
+- Neutral, because argument c
+- Bad, because argument d
+- …
+
+<!-- This is an optional element. Feel free to remove. -->
+
+## More Information
+
+You might want to provide additional evidence/confidence for the decision outcome here and/or
+document the team agreement on the decision and/or
+define when this decision when and how the decision should be realized and if/when it should be re-visited and/or
+how the decision is validated.
+Links to other decisions and resources might appear here as well.


### PR DESCRIPTION
This pull request adds a template for Architecture Decision Records (ADRs) to the repository. ADRs are used to document important architectural decisions made during the development process. This template provides a structure for ADRs, including sections for context, problem statement, decision drivers, considered options, decision outcome, consequences, validation, pros and cons, and more information.