### PR TITLE
Fix configuration for "Edit this page" link

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -38,14 +38,14 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/simnova/ownercommunity/tree/main/docusaurus/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/simnova/ownercommunity/tree/main/docusaurus/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
This pull request fixes the configuration of the "Edit this page" link in the Docusaurus documentation. Currently, the link is associated with the Docusaurus repository, but it should be configured to edit the current repository. This PR updates the editUrl configuration in the Docusaurus configuration file to point to the correct repository. Fixes #31.