### PR TITLE
Update MADR Open Telemetry contact and participants

### DIFF
--- a/docusaurus/docs/decisions/0002-open-telemetry.md
+++ b/docusaurus/docs/decisions/0002-open-telemetry.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
-sidebar_label: 002 MADR Open Telemetry
-description: "Use Markdown Any Decision Records (MADR) to track Open Telemetry Decisions."
+sidebar_label: 002 Open Telemetry
+description: "Open Telemetry Decisions."
 # These are optional elements. Feel free to remove any of them.
 status: accepted
 contact: heruwala


### PR DESCRIPTION
This pull request updates the contact and participants information for the MADR Open Telemetry decision. The sidebar label has been changed to "002 Open Telemetry" and the description has been updated to "Open Telemetry Decisions."