### PR TITLE
Make cors setting optional in storage-account.bicep

### DIFF
--- a/az-bicep/modules/static-website-no-customdomain/storage-account.bicep
+++ b/az-bicep/modules/static-website-no-customdomain/storage-account.bicep
@@ -58,12 +58,16 @@ param corsAllowedHeaders array
 param corsExposedHeaders array
 @description('maxAge for CORS')
 param corsMaxAgeInSeconds int
+
+// Check to see if we have cors settings to include
+var includeCorsRules = length(corsAllowedOrigins) > 1 || (length(corsAllowedOrigins) == 1 && corsAllowedOrigins[0] != '')
+
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-05-01' = {
   parent: storageAccount
   name: 'default'
   properties: {
     cors: {
-      corsRules: [
+      corsRules: includeCorsRules ? [
         {
           allowedOrigins: corsAllowedOrigins
           allowedMethods: corsAllowedMethods
@@ -71,7 +75,7 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-05-01'
           exposedHeaders: corsExposedHeaders
           maxAgeInSeconds: corsMaxAgeInSeconds
         }
-      ]
+      ] : []
     }
     deleteRetentionPolicy: {
       allowPermanentDelete: false

--- a/az-bicep/modules/static-website/storage-account.bicep
+++ b/az-bicep/modules/static-website/storage-account.bicep
@@ -58,12 +58,16 @@ param corsAllowedHeaders array
 param corsExposedHeaders array
 @description('maxAge for CORS')
 param corsMaxAgeInSeconds int
+
+// Check to see if we have cors settings to include
+var includeCorsRules = length(corsAllowedOrigins) > 1 || (length(corsAllowedOrigins) == 1 && corsAllowedOrigins[0] != '')
+
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-05-01' = {
   parent: storageAccount
   name: 'default'
   properties: {
     cors: {
-      corsRules: [
+      corsRules: includeCorsRules ? [
         {
           allowedOrigins: corsAllowedOrigins
           allowedMethods: corsAllowedMethods
@@ -71,7 +75,7 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-05-01'
           exposedHeaders: corsExposedHeaders
           maxAgeInSeconds: corsMaxAgeInSeconds
         }
-      ]
+      ] : []
     }
     deleteRetentionPolicy: {
       allowPermanentDelete: false


### PR DESCRIPTION
This pull request makes the cors setting optional in the storage-account.bicep file. It introduces a check to see if there are cors settings to include, and only includes them if there are. This change improves flexibility and allows for more granular control over cors configurations.