### PR TITLE
update resource group name

### DIFF
--- a/ui-community/azure-pipelines.yml
+++ b/ui-community/azure-pipelines.yml
@@ -32,7 +32,7 @@ variables:
     subscription: 'OwnerCommunity'
     #dev
     environmentNameDev: 'oc-dev'
-    ResourceGroupNameDev: 'corp-dev-rg'
+    ResourceGroupNameDev: 'rg-owner-community'
     destinationBlobContainerDev: 'ocdevstuicavaqbizf2s7le'
     cdnProfileDev: 'cdn-dev-ms-standard'
     cdnNameDev: 'oc-dev-cdne-uia-avaqbizf2s7le'


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the resource group name in the Azure Pipelines configuration file for the development environment to 'rg-owner-community'.

* **Build**:
    - Updated the resource group name in the Azure Pipelines configuration for the development environment.

<!-- Generated by sourcery-ai[bot]: end summary -->