### PR TITLE
update to existing rg

### DIFF
--- a/data-access/azure-pipelines.yml
+++ b/data-access/azure-pipelines.yml
@@ -58,7 +58,7 @@ stages:
       vmImageName: $(vmImageName)
       ServiceConnectionName: $(ServiceConnectionName)
       deploymentDefaultLocation: $(deploymentDefaultLocation)
-      resourceGroupName: 'corp-core-rg'
+      resourceGroupName: 'rg-owner-community'
 
   # - template: ./build-pipeline/core/function-app-deployment-stage.yml
   #   parameters: 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the resource group name in the Azure Pipelines configuration to align with the new naming conventions.

* **Deployment**:
    - Updated the resource group name in the Azure Pipelines configuration from 'corp-core-rg' to 'rg-owner-community'.

<!-- Generated by sourcery-ai[bot]: end summary -->