### PR TITLE
Update location for app service plans in parameters.json

### DIFF
--- a/data-access/iac/parameters.json
+++ b/data-access/iac/parameters.json
@@ -19,7 +19,7 @@
                     {
                         "run": true,
                         "name": "sec-001",
-                        "location": "westus3",
+                        "location": "westus2",
                         "sku": "B1",
                         "operatingSystem": "linux",
                         "tags": {
@@ -58,7 +58,7 @@
                         "name": "sec",
                         "appServicePlanName": "oc-dev-asp-sec-001",
                         "appServicePlanSku": "B1",
-                        "location": "westus3",
+                        "location": "westus2",
                         "storageAccountName": "ocdevstfuncwestus3",
                         "functionApp": {
                             "maxOldSpaceSizeMB": "3072",


### PR DESCRIPTION
This pull request updates the location for app service plans in the parameters.json file. The location is changed from "westus3" to "westus2". This change ensures that the app service plans are created in the correct region.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Updated the location for app service plans in parameters.json from 'westus3' to 'westus2' to ensure correct region deployment.

<!-- Generated by sourcery-ai[bot]: end summary -->