### PR TITLE
Violation Ticket Permissions Fix

### DIFF
--- a/data-access/src/app/application-services-impl/datastore/member.ts
+++ b/data-access/src/app/application-services-impl/datastore/member.ts
@@ -149,7 +149,11 @@ export class MemberDataApiImpl
       p?.communityPermissions?.canManageCommunitySettings ||
       p?.communityPermissions?.canManageSiteContent ||
       p?.communityPermissions?.canManageMembers ||
-      p?.propertyPermissions?.canManageProperties
+      p?.propertyPermissions?.canManageProperties ||
+      p?.violationTicketPermissions?.canManageTickets ||
+      p?.violationTicketPermissions?.canAssignTickets ||
+      p?.violationTicketPermissions?.canWorkOnTickets ||
+      p?.violationTicketPermissions?.canCreateTickets
     );
   }
 }

--- a/ui-community/src/components/layouts/admin/index.tsx
+++ b/ui-community/src/components/layouts/admin/index.tsx
@@ -81,7 +81,8 @@ export const Admin: React.FC<any> = (_props) => {
       icon: <ScheduleOutlined />,
       id: 7,
       parent: 'ROOT',
-      hasPermissions: (member: Member) => member?.role?.permissions?.serviceTicketPermissions?.canManageTickets ?? false
+      hasPermissions: (member: Member) => (member?.role?.permissions?.serviceTicketPermissions?.canManageTickets || 
+                                          member?.role?.permissions?.violationTicketPermissions?.canManageTickets) ?? false
     }
   ];
 


### PR DESCRIPTION
Fixed bugs related to violation ticket permissions

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses bugs related to violation ticket permissions by updating the permission checks to include additional roles such as canManageTickets, canAssignTickets, canWorkOnTickets, and canCreateTickets.

- **Bug Fixes**:
    - Fixed permission checks for violation tickets to include canManageTickets, canAssignTickets, canWorkOnTickets, and canCreateTickets.

<!-- Generated by sourcery-ai[bot]: end summary -->