### PR TITLE
Revise refund and void payment code

### DIFF
--- a/data-access/seedwork/services-seedwork-payment-cybersource-interfaces/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource-interfaces/index.ts
@@ -8,8 +8,8 @@ export interface CybersourceBase {
   deleteCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean>;
   setDefaultCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<CustomerPaymentResponse>;
   processPayment(clientReferenceCode: string, paymentInstrumentId: string, amount: number): Promise<PaymentTransactionResponse>;
-  refundPayment(paymentInstrumentId: string, amount: number): Promise<PaymentTransactionResponse>;
-  voidPayment(clientReferenceCode: string, amount: number): Promise<PaymentTransactionResponse>;
+  refundPayment(requestId: string, amount: number): Promise<RefundPaymentResponse>;
+  voidPayment(clientReferenceCode: string, requestId: string, amount: number): Promise<PaymentTransactionResponse>;
 }
 
 export interface CustomerProfile {
@@ -183,4 +183,25 @@ export interface CustomerPaymentInstrumentsResponse {
   _embedded: {
     paymentInstruments: PaymentInstrument[];
   };
+}
+
+export interface RefundPaymentResponse {
+  _links: {
+    self: {
+      href: string,
+      method: string
+    },
+    void: {
+      href: string,
+      method: string
+    }
+  },
+  id: string,
+  submitTimeUtc: string,
+  status: string,
+  reconciliationId: string,
+  clientReferenceInformation: { code: string },
+  refundAmountDetails: { refundAmount: string, currency: string },
+  processorInformation: { approvalCode: string, responseCode: string },
+  orderInformation: {}
 }

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
@@ -3,6 +3,7 @@ import {
   CustomerPaymentInstrumentsResponse,
   PaymentTransactionResponse,
   CustomerPaymentInstrumentResponse,
+  RefundPaymentResponse
 } from '../services-seedwork-payment-cybersource-interfaces';
 import { Cybersource } from './index';
 
@@ -130,24 +131,22 @@ test.skip('cybersource: process payment', async () => {
 });
 
 test.skip('cybersource: refund payment', async () => {
-  const clientReferenceCode = 'TC55971_4';
+  const requestId = '7210836357566150004953'; // 7210836357566150004953
   const amount: number = 100.55;
-  const response: PaymentTransactionResponse = await cybersource.refundPayment(clientReferenceCode, amount);
+  const response: RefundPaymentResponse = await cybersource.refundPayment(requestId, amount);
 
   expect(response).toBeDefined();
-  expect(response.status).toBe('AUTHORIZED');
-  //expect(response.orderInformation.amountDetails.authorizedAmount).toBe(amount.toString());
-  //expect(response.processorInformation.approvalCode).toEqual('888888');
-  //expect(response.processorInformation.transactionId).toBeDefined();
-  // expect below
-  // refundId: refundResponse.id,
-  // responseCode: refundResponse.processorInformation.responseCode
+  expect(response.status).toBe('PENDING');
+  expect(response.processorInformation.responseCode).toBe('100');
+  expect(response.refundAmountDetails.refundAmount).toBe(amount.toString());
 });
 
 test.skip('cybersource: void payment', async () => {
-  const paymentInstrumentId = '1D29E9E8A73A6A8AE063AF598E0AB009';
+  // payments can only be voided if Cybersource has not already submitted the payment to the payment processor
+  const clientReferenceCode = 'TC55971_4';
+  const requestId = '7206168236136411104008';
   const amount: number = 199.99;
-  const response: PaymentTransactionResponse = await cybersource.voidPayment(paymentInstrumentId, amount);
+  const response: PaymentTransactionResponse = await cybersource.voidPayment(clientReferenceCode, requestId, amount);
 
   expect(response).toBeDefined();
   expect(response.status).toBe('AUTHORIZED');

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -385,7 +385,6 @@ export class Cybersource implements CybersourceBase {
 
     // create a new ProcessingInformation object
     let processingInformation = new cybersource.Ptsv2paymentsProcessingInformation();
-    //processingInformation.actionList = ['AUTHORIZE']; // Actions to authorize payment
     processingInformation.capture = true; // Capture the payment
 
     // create a new PaymentInformation object
@@ -437,10 +436,8 @@ export class Cybersource implements CybersourceBase {
     return new Promise((resolve, reject) => {
       instance.refundCapture(refundCaptureRequest, requestId, (error, data, response) => {
         if (!error) {
-          console.log('Refund response: ', JSON.stringify(data));
           resolve(data as RefundPaymentResponse);
         } else {
-          console.log('Refund error: ', error.message);
           reject(new Error(error.message || 'Unknown error occurred in refunding payment'));
         }
       });
@@ -462,11 +459,8 @@ export class Cybersource implements CybersourceBase {
     return new Promise((resolve, reject) => {
       instance.voidCapture(voidCaptureRequest, requestId, (error, data, response) => {
         if (!error) {
-          console.log('Void data: ', JSON.stringify(data));
-          console.log('Void response: ', JSON.stringify(response));
           resolve(data as PaymentTransactionResponse);
         } else {
-          console.log('Void error: ', error);
           reject(new Error(error.message || 'Unknown error occurred in voiding payment'));
         }
       });

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -8,6 +8,7 @@ import {
   CustomerPaymentInstrumentsResponse,
   CustomerPaymentResponse,
   CustomerPaymentInstrumentResponse,
+  RefundPaymentResponse
 } from '../services-seedwork-payment-cybersource-interfaces';
 
 export class Cybersource implements CybersourceBase {
@@ -412,7 +413,7 @@ export class Cybersource implements CybersourceBase {
   }
 
 
-  async refundPayment(clientReferenceCode: string, amount: number): Promise<PaymentTransactionResponse> {
+  async refundPayment(requestId: string, amount: number): Promise<RefundPaymentResponse> {
     const instance = new cybersource.RefundApi(this._configObject, this._cybersourceClient);
 
     // create a new OrderInformationAmountDetails object
@@ -434,10 +435,10 @@ export class Cybersource implements CybersourceBase {
     refundCaptureRequest.processingInformation = processingInformation;
 
     return new Promise((resolve, reject) => {
-      instance.refundCapture(refundCaptureRequest, clientReferenceCode, (error, data, response) => {
+      instance.refundCapture(refundCaptureRequest, requestId, (error, data, response) => {
         if (!error) {
           console.log('Refund response: ', JSON.stringify(data));
-          resolve(data as PaymentTransactionResponse);
+          resolve(data as RefundPaymentResponse);
         } else {
           console.log('Refund error: ', error.message);
           reject(new Error(error.message || 'Unknown error occurred in refunding payment'));
@@ -446,7 +447,7 @@ export class Cybersource implements CybersourceBase {
     });
   }
 
-  async voidPayment(clientReferenceCode: string, amount: number): Promise<PaymentTransactionResponse> {
+  async voidPayment(clientReferenceCode: string, requestId: string, amount: number): Promise<PaymentTransactionResponse> {
     const instance = new cybersource.VoidApi(this._configObject, this._cybersourceClient);
 
     // create a new ClientReferenceInformation object used for reconciliation purposes (search)
@@ -459,12 +460,13 @@ export class Cybersource implements CybersourceBase {
     voidCaptureRequest.clientReferenceInformation = clientReferenceInformation;
 
     return new Promise((resolve, reject) => {
-      instance.voidCapture(voidCaptureRequest, clientReferenceCode, (error, data, response) => {
+      instance.voidCapture(voidCaptureRequest, requestId, (error, data, response) => {
         if (!error) {
           console.log('Void data: ', JSON.stringify(data));
           console.log('Void response: ', JSON.stringify(response));
           resolve(data as PaymentTransactionResponse);
         } else {
+          console.log('Void error: ', error);
           reject(new Error(error.message || 'Unknown error occurred in voiding payment'));
         }
       });

--- a/data-access/src/app/infrastructure-services/payment/index.ts
+++ b/data-access/src/app/infrastructure-services/payment/index.ts
@@ -4,6 +4,7 @@ import {
   CustomerPaymentInstrumentsResponse,
   CustomerPaymentResponse,
   CustomerPaymentInstrumentResponse,
+  RefundPaymentResponse
 } from '../../../../seedwork/services-seedwork-payment-cybersource-interfaces';
 
 export interface PaymentInfrastructureService {
@@ -16,6 +17,6 @@ export interface PaymentInfrastructureService {
   deleteCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean>;
   setDefaultCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<CustomerPaymentResponse>;
   processPayment(clientReferenceCode: string, paymentInstrumentId: string, amount: number): Promise<PaymentTransactionResponse>;
-  refundPayment(paymentInstrumentId: string, amount: number): Promise<PaymentTransactionResponse>;
-  voidPayment(clientReferenceCode: string, amount: number): Promise<PaymentTransactionResponse>;
+  refundPayment(paymentInstrumentId: string, amount: number): Promise<RefundPaymentResponse>;
+  voidPayment(clientReferenceCode: string, requestId: string, amount: number): Promise<PaymentTransactionResponse>;
 }


### PR DESCRIPTION
This pull request includes changes to the refund and void payment code. The `refundPayment` method now accepts a `requestId` parameter instead of a `clientReferenceCode` parameter, and returns a `RefundPaymentResponse` object. The `voidPayment` method now accepts a `requestId` parameter in addition to the `clientReferenceCode` parameter, and returns a `PaymentTransactionResponse` object. These changes improve the functionality and accuracy of the refund and void payment processes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Revised the refund and void payment methods to improve functionality and accuracy by changing parameter requirements and response types. Updated corresponding test cases to reflect these changes.

- **Enhancements**:
    - Updated the `refundPayment` method to accept a `requestId` parameter instead of `clientReferenceCode` and return a `RefundPaymentResponse` object.
    - Modified the `voidPayment` method to accept an additional `requestId` parameter along with `clientReferenceCode` and return a `PaymentTransactionResponse` object.
- **Tests**:
    - Adjusted test cases for `refundPayment` to use `requestId` and validate against `RefundPaymentResponse`.
    - Updated test cases for `voidPayment` to include `requestId` and validate the response.

<!-- Generated by sourcery-ai[bot]: end summary -->