### PR TITLE
feat: added payemnt resolvers for delete, mark as default, get paymen…

### DIFF
--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
@@ -102,7 +102,6 @@ test.skip('cybersource: get customer payment instrument', async () => {
 test.skip('cybersource: get customer payment instruments', async () => {
   const customerId = '1CD4C5EE92E27A57E063AF598E0ACEC6';
   const response: CustomerPaymentInstrumentsResponse = await cybersource.getCustomerPaymentInstruments(customerId);
-
   expect(response).toBeDefined();
   expect(response.total).toBeGreaterThan(0);
   expect(response._embedded.paymentInstruments.length).toBeGreaterThan(0);

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -355,7 +355,8 @@ throw new Error('paymentTokenInfo or its required properties are null or undefin
         if (!error) {
           resolve(true);
         } else {
-          reject(new Error(error.message || 'Unknown error occurred in deleting customer payment instrument'));
+          const errors = error?.response?.body?.errors.map((error) => error.message).join(', ');
+          reject(new Error(errors || 'Unknown error occurred in deleting customer payment instrument'));
         }
       });
     });

--- a/data-access/src/app/application-services-impl/payment/payment.ts
+++ b/data-access/src/app/application-services-impl/payment/payment.ts
@@ -57,12 +57,12 @@ export class PaymentApiImpl extends PaymentDataSource<AppContext> implements Pay
     await this.withCybersource(async (_passport, cybersource: Cybersource) => {
       cyberSourcePaymentInstrumentsResponse = await cybersource.getCustomerPaymentInstruments(customerId);
     });
-    response = cyberSourcePaymentInstrumentsResponse._embedded.paymentInstruments.map((paymentInstrument) => {
+    response = cyberSourcePaymentInstrumentsResponse?._embedded?.paymentInstruments.map((paymentInstrument) => {
       return {
-        cardNumber: paymentInstrument._embedded.instrumentIdentifier.card.number,
-        cardType: paymentInstrument.card.type,
-        paymentInstrumentId: paymentInstrument.id,
-        isDefault: paymentInstrument.default,
+        cardNumber: paymentInstrument?._embedded?.instrumentIdentifier?.card?.number,
+        cardType: paymentInstrument?.card?.type,
+        paymentInstrumentId: paymentInstrument?.id,
+        isDefault: paymentInstrument?.default,
       };
     });
     return response;

--- a/data-access/src/app/application-services-impl/payment/payment.ts
+++ b/data-access/src/app/application-services-impl/payment/payment.ts
@@ -1,9 +1,14 @@
 import { PaymentDataSource } from './payment-data-source';
 import { PaymentApi } from '../../application-services';
 import { AppContext } from '../../init/app-context-builder';
-import { AddPaymentInstrumentInput } from '../../external-dependencies/graphql-api';
+import { AddPaymentInstrumentInput, PaymentInstrument } from '../../external-dependencies/graphql-api';
 import { Cybersource } from '../../../../seedwork/services-seedwork-payment-cybersource';
-import { CustomerProfile, PaymentTokenInfo } from '../../../../seedwork/services-seedwork-payment-cybersource-interfaces';
+import {
+  CustomerPaymentInstrumentsResponse,
+  CustomerPaymentResponse,
+  CustomerProfile,
+  PaymentTokenInfo,
+} from '../../../../seedwork/services-seedwork-payment-cybersource-interfaces';
 
 export class PaymentApiImpl extends PaymentDataSource<AppContext> implements PaymentApi {
   public async generatePublicKey(): Promise<string> {
@@ -44,5 +49,38 @@ export class PaymentApiImpl extends PaymentDataSource<AppContext> implements Pay
       response = await cybersource.addCustomerPaymentInstrument(customerProfile, paymentTokenInfo);
     });
     return response.status === 'AUTHORIZED';
+  }
+
+  public async getPaymentInstruments(customerId: string): Promise<PaymentInstrument[]> {
+    let response;
+    let cyberSourcePaymentInstrumentsResponse: CustomerPaymentInstrumentsResponse;
+    await this.withCybersource(async (_passport, cybersource: Cybersource) => {
+      cyberSourcePaymentInstrumentsResponse = await cybersource.getCustomerPaymentInstruments(customerId);
+    });
+    response = cyberSourcePaymentInstrumentsResponse._embedded.paymentInstruments.map((paymentInstrument) => {
+      return {
+        cardNumber: paymentInstrument._embedded.instrumentIdentifier.card.number,
+        cardType: paymentInstrument.card.type,
+        paymentInstrumentId: paymentInstrument.id,
+        isDefault: paymentInstrument.default,
+      };
+    });
+    return response;
+  }
+
+  public async setDefaultPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean> {
+    let response: CustomerPaymentResponse;
+    await this.withCybersource(async (_passport, cybersource: Cybersource) => {
+      response = await cybersource.setDefaultCustomerPaymentInstrument(customerId, paymentInstrumentId);
+    });
+    return response._embedded.defaultPaymentInstrument.id === paymentInstrumentId;
+  }
+
+  public async deletePaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean> {
+    let response: boolean;
+    await this.withCybersource(async (_passport, cybersource: Cybersource) => {
+      response = await cybersource.deleteCustomerPaymentInstrument(customerId, paymentInstrumentId);
+    });
+    return response;
   }
 }

--- a/data-access/src/app/application-services/payment/payment.interface.ts
+++ b/data-access/src/app/application-services/payment/payment.interface.ts
@@ -1,8 +1,11 @@
 import { CustomerProfile, PaymentTokenInfo } from "../../../../seedwork/services-seedwork-payment-cybersource-interfaces";
-import { AddPaymentInstrumentInput } from "../../external-dependencies/graphql-api";
+import { AddPaymentInstrumentInput, PaymentInstrument } from "../../external-dependencies/graphql-api";
 
 export interface PaymentApplicationService {
   generatePublicKey(): Promise<string>;
   createCybersouceCustomer(paymentInstrument: AddPaymentInstrumentInput): Promise<string>
   addPaymentInstrument(paymentInstrument: CustomerProfile, paymentTokenInfo: PaymentTokenInfo): Promise<boolean>
+  getPaymentInstruments(customerId: string): Promise<PaymentInstrument[]>
+  setDefaultPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean>
+  deletePaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean>
 }

--- a/data-access/src/graphql/schema/builder/generated.ts
+++ b/data-access/src/graphql/schema/builder/generated.ts
@@ -608,9 +608,11 @@ export type Mutation = {
   memberAccountRemove: MemberMutationResult;
   memberAddPaymentInstrument: MemberMutationResult;
   memberCreate: MemberMutationResult;
+  memberDeletePaymentInstrument: MutationStatus;
   memberProfileAvatarCreateAuthHeader: MemberAvatarImageAuthHeaderResult;
   memberProfileAvatarRemove: MemberMutationResult;
   memberProfileUpdate: MemberMutationResult;
+  memberSetDefaultPaymentInstrument: MutationStatus;
   memberUpdate: MemberMutationResult;
   propertyAdd: PropertyMutationResult;
   propertyAssignOwner: PropertyMutationResult;
@@ -696,6 +698,11 @@ export type MutationMemberCreateArgs = {
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationMemberDeletePaymentInstrumentArgs = {
+  paymentInstrumentId: Scalars['String'];
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationMemberProfileAvatarCreateAuthHeaderArgs = {
   input: MemberAvatarImageInput;
 };
@@ -708,6 +715,11 @@ export type MutationMemberProfileAvatarRemoveArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationMemberProfileUpdateArgs = {
   input: MemberProfileUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationMemberSetDefaultPaymentInstrumentArgs = {
+  paymentInstrumentId: Scalars['String'];
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -868,6 +880,20 @@ export type MutationStatus = {
   __typename?: 'MutationStatus';
   errorMessage?: Maybe<Scalars['String']>;
   success: Scalars['Boolean'];
+};
+
+export type PaymentInstrument = {
+  __typename?: 'PaymentInstrument';
+  cardNumber?: Maybe<Scalars['String']>;
+  cardType?: Maybe<Scalars['String']>;
+  isDefault?: Maybe<Scalars['Boolean']>;
+  paymentInstrumentId?: Maybe<Scalars['String']>;
+};
+
+export type PaymentInstrumentResult = {
+  __typename?: 'PaymentInstrumentResult';
+  paymentInstruments?: Maybe<Array<Maybe<PaymentInstrument>>>;
+  status: MutationStatus;
 };
 
 export type PermissionsInput = {
@@ -1056,6 +1082,7 @@ export type Query = {
   member?: Maybe<Member>;
   memberAssignableToViolationTickets?: Maybe<Member>;
   memberForCurrentUser?: Maybe<Member>;
+  memberPaymentInstruments?: Maybe<PaymentInstrumentResult>;
   members?: Maybe<Array<Maybe<Member>>>;
   membersAssignableToTickets?: Maybe<Array<Maybe<Member>>>;
   membersByCommunityId?: Maybe<Array<Maybe<Member>>>;
@@ -1772,6 +1799,8 @@ export type ResolversTypes = ResolversObject<{
   NonPositiveFloat: ResolverTypeWrapper<Scalars['NonPositiveFloat']>;
   NonPositiveInt: ResolverTypeWrapper<Scalars['NonPositiveInt']>;
   ObjectID: ResolverTypeWrapper<Scalars['ObjectID']>;
+  PaymentInstrument: ResolverTypeWrapper<PaymentInstrument>;
+  PaymentInstrumentResult: ResolverTypeWrapper<PaymentInstrumentResult>;
   PermissionsInput: PermissionsInput;
   PhoneNumber: ResolverTypeWrapper<Scalars['PhoneNumber']>;
   Point: ResolverTypeWrapper<Point>;
@@ -1997,6 +2026,8 @@ export type ResolversParentTypes = ResolversObject<{
   NonPositiveFloat: Scalars['NonPositiveFloat'];
   NonPositiveInt: Scalars['NonPositiveInt'];
   ObjectID: Scalars['ObjectID'];
+  PaymentInstrument: PaymentInstrument;
+  PaymentInstrumentResult: PaymentInstrumentResult;
   PermissionsInput: PermissionsInput;
   PhoneNumber: Scalars['PhoneNumber'];
   Point: Point;
@@ -2623,6 +2654,12 @@ export type MutationResolvers<ContextType = GraphqlContext, ParentType extends R
   memberAccountRemove?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberAccountRemoveArgs, 'input'>>;
   memberAddPaymentInstrument?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberAddPaymentInstrumentArgs, 'input'>>;
   memberCreate?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberCreateArgs, 'input'>>;
+  memberDeletePaymentInstrument?: Resolver<
+    ResolversTypes['MutationStatus'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationMemberDeletePaymentInstrumentArgs, 'paymentInstrumentId'>
+  >;
   memberProfileAvatarCreateAuthHeader?: Resolver<
     ResolversTypes['MemberAvatarImageAuthHeaderResult'],
     ParentType,
@@ -2631,6 +2668,12 @@ export type MutationResolvers<ContextType = GraphqlContext, ParentType extends R
   >;
   memberProfileAvatarRemove?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberProfileAvatarRemoveArgs, 'memberId'>>;
   memberProfileUpdate?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberProfileUpdateArgs, 'input'>>;
+  memberSetDefaultPaymentInstrument?: Resolver<
+    ResolversTypes['MutationStatus'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationMemberSetDefaultPaymentInstrumentArgs, 'paymentInstrumentId'>
+  >;
   memberUpdate?: Resolver<ResolversTypes['MemberMutationResult'], ParentType, ContextType, RequireFields<MutationMemberUpdateArgs, 'input'>>;
   propertyAdd?: Resolver<ResolversTypes['PropertyMutationResult'], ParentType, ContextType, RequireFields<MutationPropertyAddArgs, 'input'>>;
   propertyAssignOwner?: Resolver<ResolversTypes['PropertyMutationResult'], ParentType, ContextType, RequireFields<MutationPropertyAssignOwnerArgs, 'input'>>;
@@ -2749,6 +2792,26 @@ export interface NonPositiveIntScalarConfig extends GraphQLScalarTypeConfig<Reso
 export interface ObjectIdScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ObjectID'], any> {
   name: 'ObjectID';
 }
+
+export type PaymentInstrumentResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['PaymentInstrument'] = ResolversParentTypes['PaymentInstrument'],
+> = ResolversObject<{
+  cardNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cardType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  paymentInstrumentId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PaymentInstrumentResultResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['PaymentInstrumentResult'] = ResolversParentTypes['PaymentInstrumentResult'],
+> = ResolversObject<{
+  paymentInstruments?: Resolver<Maybe<Array<Maybe<ResolversTypes['PaymentInstrument']>>>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['MutationStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export interface PhoneNumberScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['PhoneNumber'], any> {
   name: 'PhoneNumber';
@@ -2898,6 +2961,7 @@ export type QueryResolvers<ContextType = GraphqlContext, ParentType extends Reso
     RequireFields<QueryMemberAssignableToViolationTicketsArgs, 'violationTicketId'>
   >;
   memberForCurrentUser?: Resolver<Maybe<ResolversTypes['Member']>, ParentType, ContextType>;
+  memberPaymentInstruments?: Resolver<Maybe<ResolversTypes['PaymentInstrumentResult']>, ParentType, ContextType>;
   members?: Resolver<Maybe<Array<Maybe<ResolversTypes['Member']>>>, ParentType, ContextType>;
   membersAssignableToTickets?: Resolver<Maybe<Array<Maybe<ResolversTypes['Member']>>>, ParentType, ContextType>;
   membersByCommunityId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Member']>>>, ParentType, ContextType, RequireFields<QueryMembersByCommunityIdArgs, 'communityId'>>;
@@ -3352,6 +3416,8 @@ export type Resolvers<ContextType = GraphqlContext> = ResolversObject<{
   NonPositiveFloat?: GraphQLScalarType;
   NonPositiveInt?: GraphQLScalarType;
   ObjectID?: GraphQLScalarType;
+  PaymentInstrument?: PaymentInstrumentResolvers<ContextType>;
+  PaymentInstrumentResult?: PaymentInstrumentResultResolvers<ContextType>;
   PhoneNumber?: GraphQLScalarType;
   Point?: PointResolvers<ContextType>;
   Port?: GraphQLScalarType;

--- a/data-access/src/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/graphql/schema/builder/graphql.schema.json
@@ -5732,6 +5732,39 @@
             "deprecationReason": null
           },
           {
+            "name": "memberDeletePaymentInstrument",
+            "description": null,
+            "args": [
+              {
+                "name": "paymentInstrumentId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MutationStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "memberProfileAvatarCreateAuthHeader",
             "description": null,
             "args": [
@@ -5824,6 +5857,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "MemberMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "memberSetDefaultPaymentInstrument",
+            "description": null,
+            "args": [
+              {
+                "name": "paymentInstrumentId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MutationStatus",
                 "ofType": null
               }
             },
@@ -7031,6 +7097,108 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentInstrument",
+        "description": null,
+        "fields": [
+          {
+            "name": "cardNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cardType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDefault",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paymentInstrumentId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PaymentInstrumentResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "paymentInstruments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PaymentInstrument",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MutationStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8960,6 +9128,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "Member",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "memberPaymentInstruments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PaymentInstrumentResult",
               "ofType": null
             },
             "isDeprecated": false,

--- a/data-access/src/graphql/schema/types/member.graphql
+++ b/data-access/src/graphql/schema/types/member.graphql
@@ -62,6 +62,7 @@ extend type Query {
   memberAssignableToViolationTickets(violationTicketId: ObjectID!): Member
   memberForCurrentUser: Member
   cybersourcePublicKeyId: String
+  memberPaymentInstruments: PaymentInstrumentResult
 }
 
 extend type Mutation {
@@ -74,6 +75,8 @@ extend type Mutation {
   memberProfileAvatarCreateAuthHeader(input: MemberAvatarImageInput!): MemberAvatarImageAuthHeaderResult!
   memberProfileAvatarRemove(memberId: ObjectID!): MemberMutationResult!
   memberAddPaymentInstrument(input: AddPaymentInstrumentInput!): MemberMutationResult!
+  memberSetDefaultPaymentInstrument(paymentInstrumentId: String!): MutationStatus!
+  memberDeletePaymentInstrument(paymentInstrumentId: String!): MutationStatus!
 }
 
 type MemberMutationResult implements MutationResult {
@@ -174,6 +177,18 @@ type Wallet {
   customerId: String
   """List of transactions associated with the customer"""
   transactions: [Transaction]
+}
+
+type PaymentInstrument {
+  cardType: String
+  paymentInstrumentId: String
+  cardNumber: String
+  isDefault: Boolean
+}
+
+type PaymentInstrumentResult {
+  status: MutationStatus!
+  paymentInstruments: [PaymentInstrument]
 }
 
 input AddPaymentInstrumentInput {

--- a/data-access/src/graphql/schema/types/member.resolvers.ts
+++ b/data-access/src/graphql/schema/types/member.resolvers.ts
@@ -32,7 +32,7 @@ const member: Resolvers = {
       return parent.role;
     },
     isAdmin: async (parent, _args, context) => {
-      return (await context.applicationServices.memberDataApi.isAdmin(parent.id));
+      return await context.applicationServices.memberDataApi.isAdmin(parent.id);
     },
   },
   MemberAccount: {
@@ -50,7 +50,7 @@ const member: Resolvers = {
     },
   },
   Query: {
-    member: async (_parent, {id}, context) => {
+    member: async (_parent, { id }, context) => {
       if (id && isValidObjectId(id)) {
         return (await context.applicationServices.memberDataApi.getMemberById(id)) as Member;
       }
@@ -74,8 +74,16 @@ const member: Resolvers = {
     memberForCurrentUser: async (_, _input, context) => {
       return getMemberForCurrentUser(context);
     },
-    cybersourcePublicKeyId: async (parent, _args, context) => {
-      return await context.applicationServices.paymentApi.generatePublicKey();
+    cybersourcePublicKeyId: async (parent, _args, { applicationServices }) => {
+      return await applicationServices.paymentApi.generatePublicKey();
+    },
+    memberPaymentInstruments: async (_, _args, context) => {
+      const member = await getMemberForCurrentUser(context);
+      if (member?.wallet?.customerId) {
+        const paymentInstruments = await context.applicationServices.paymentApi.getPaymentInstruments(member.wallet.customerId);
+        return { status: { success: true }, paymentInstruments };
+      }
+      return { status: { success: false }, paymentInstruments: [] };
     },
   },
   Mutation: {
@@ -116,27 +124,51 @@ const member: Resolvers = {
       }
     },
 
-    memberAddPaymentInstrument: async (_, {input}, context) => {
+    memberAddPaymentInstrument: async (_, { input }, context) => {
       const member = await getMemberForCurrentUser(context);
       let cyberSourceCustomerId = member?.wallet?.customerId;
-      if(!cyberSourceCustomerId) {
-          cyberSourceCustomerId = await context.applicationServices.paymentApi.createCybersouceCustomer(input);
-          console.log('createCybersouceCustomerResponse', cyberSourceCustomerId)
-          if(cyberSourceCustomerId) {
-            return await MemberMutationResolver(context.applicationServices.memberDomainApi.memberAddWallet(member.id, cyberSourceCustomerId));
-          }
+      if (!cyberSourceCustomerId) {
+        cyberSourceCustomerId = await context.applicationServices.paymentApi.createCybersouceCustomer(input);
+        console.log('createCybersouceCustomerResponse', cyberSourceCustomerId);
+        if (cyberSourceCustomerId) {
+          return await MemberMutationResolver(context.applicationServices.memberDomainApi.memberAddWallet(member.id, cyberSourceCustomerId));
+        }
       }
 
-      if(cyberSourceCustomerId) {
+      if (cyberSourceCustomerId) {
         const paymentInstrumentPayload: CustomerProfile = {
           ...input,
           customerId: cyberSourceCustomerId,
         };
-        const paymentTokenInfo: PaymentTokenInfo = {paymentToken: input.paymentToken, isDefault: input.isDefault}
+        const paymentTokenInfo: PaymentTokenInfo = { paymentToken: input.paymentToken, isDefault: input.isDefault };
         await context.applicationServices.paymentApi.addPaymentInstrument(paymentInstrumentPayload, paymentTokenInfo);
         return { status: { success: true }, member };
       }
-    }
+    },
+
+    memberSetDefaultPaymentInstrument: async (_, { paymentInstrumentId }, context) => {
+      let status: boolean;
+      const member = await getMemberForCurrentUser(context);
+      const cyberSourceCustomerId = member?.wallet?.customerId;
+      if (cyberSourceCustomerId) {
+        status = await context.applicationServices.paymentApi.setDefaultPaymentInstrument(cyberSourceCustomerId, paymentInstrumentId);
+        return { success: status, errorMessage: '' };
+      }
+    },
+
+    memberDeletePaymentInstrument: async (_, { paymentInstrumentId }, context) => {
+      const member = await getMemberForCurrentUser(context);
+      let response: boolean;
+      try {
+        const cyberSourceCustomerId = member?.wallet?.customerId;
+        if (cyberSourceCustomerId) {
+          response = await context.applicationServices.paymentApi.deletePaymentInstrument(cyberSourceCustomerId, paymentInstrumentId);
+          return { success: response };
+        }
+      } catch (error) {
+        return { success: false, errorMessage: error.message };
+      }
+    },
   },
 };
 

--- a/ui-community/src/components/layouts/members/components/billing-info.container.tsx
+++ b/ui-community/src/components/layouts/members/components/billing-info.container.tsx
@@ -100,6 +100,7 @@ export const BillingInfoContainer: React.FC<BillingInfoContainerProps> = () => {
       microformScript.src = 'https://flex.cybersource.com/cybersource/assets/microform/0.11/flex-microform.min.js';
       microformScript.async = true;
       document.body.appendChild(microformScript);
+      cssScript.defer = true;
       document.body.appendChild(cssScript);
       microformScript.onload = () => {
         console.log('script loaded');
@@ -119,7 +120,6 @@ export const BillingInfoContainer: React.FC<BillingInfoContainerProps> = () => {
         });
       };
 
-      cssScript.defer = true;
       cssScript.onload = () => {
         console.log('css loaded');
         setScriptLoaded(true);

--- a/ui-community/src/components/layouts/members/components/billing-info.container.tsx
+++ b/ui-community/src/components/layouts/members/components/billing-info.container.tsx
@@ -99,8 +99,8 @@ export const BillingInfoContainer: React.FC<BillingInfoContainerProps> = () => {
       cssScript.src = `${window.location.origin.toString()}/scripts/microform-css.js`;
       microformScript.src = 'https://flex.cybersource.com/cybersource/assets/microform/0.11/flex-microform.min.js';
       microformScript.async = true;
-      document.body.appendChild(microformScript);
       cssScript.defer = true;
+      document.body.appendChild(microformScript);
       document.body.appendChild(cssScript);
       microformScript.onload = () => {
         console.log('script loaded');

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -606,9 +606,11 @@ export type Mutation = {
   memberAccountRemove: MemberMutationResult;
   memberAddPaymentInstrument: MemberMutationResult;
   memberCreate: MemberMutationResult;
+  memberDeletePaymentInstrument: MutationStatus;
   memberProfileAvatarCreateAuthHeader: MemberAvatarImageAuthHeaderResult;
   memberProfileAvatarRemove: MemberMutationResult;
   memberProfileUpdate: MemberMutationResult;
+  memberSetDefaultPaymentInstrument: MutationStatus;
   memberUpdate: MemberMutationResult;
   propertyAdd: PropertyMutationResult;
   propertyAssignOwner: PropertyMutationResult;
@@ -694,6 +696,11 @@ export type MutationMemberCreateArgs = {
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationMemberDeletePaymentInstrumentArgs = {
+  paymentInstrumentId: Scalars['String'];
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationMemberProfileAvatarCreateAuthHeaderArgs = {
   input: MemberAvatarImageInput;
 };
@@ -706,6 +713,11 @@ export type MutationMemberProfileAvatarRemoveArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationMemberProfileUpdateArgs = {
   input: MemberProfileUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationMemberSetDefaultPaymentInstrumentArgs = {
+  paymentInstrumentId: Scalars['String'];
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -866,6 +878,20 @@ export type MutationStatus = {
   __typename?: 'MutationStatus';
   errorMessage?: Maybe<Scalars['String']>;
   success: Scalars['Boolean'];
+};
+
+export type PaymentInstrument = {
+  __typename?: 'PaymentInstrument';
+  cardNumber?: Maybe<Scalars['String']>;
+  cardType?: Maybe<Scalars['String']>;
+  isDefault?: Maybe<Scalars['Boolean']>;
+  paymentInstrumentId?: Maybe<Scalars['String']>;
+};
+
+export type PaymentInstrumentResult = {
+  __typename?: 'PaymentInstrumentResult';
+  paymentInstruments?: Maybe<Array<Maybe<PaymentInstrument>>>;
+  status: MutationStatus;
 };
 
 export type PermissionsInput = {
@@ -1054,6 +1080,7 @@ export type Query = {
   member?: Maybe<Member>;
   memberAssignableToViolationTickets?: Maybe<Member>;
   memberForCurrentUser?: Maybe<Member>;
+  memberPaymentInstruments?: Maybe<PaymentInstrumentResult>;
   members?: Maybe<Array<Maybe<Member>>>;
   membersAssignableToTickets?: Maybe<Array<Maybe<Member>>>;
   membersByCommunityId?: Maybe<Array<Maybe<Member>>>;


### PR DESCRIPTION
…t instruments

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds new GraphQL resolvers and types to manage payment instruments, including functionalities to delete, mark as default, and retrieve payment instruments. It also updates the PaymentApi implementation to support these new operations.

- **New Features**:
    - Introduced GraphQL resolvers for deleting a payment instrument, marking a payment instrument as default, and retrieving payment instruments for a member.
    - Added new GraphQL types for PaymentInstrument and PaymentInstrumentResult to handle payment instrument data.
- **Enhancements**:
    - Updated the PaymentApi implementation to include methods for getting, setting as default, and deleting payment instruments.
    - Refactored member resolvers to include new functionalities for managing payment instruments.

<!-- Generated by sourcery-ai[bot]: end summary -->