### PR TITLE
Add updateCustomerPaymentInstrument method to CybersourceBase interface

### DIFF
--- a/data-access/seedwork/services-seedwork-payment-cybersource-interfaces/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource-interfaces/index.ts
@@ -7,6 +7,7 @@ export interface CybersourceBase {
   getCustomerPaymentInstruments(customerId: string, offset?: number, limit?: number): Promise<CustomerPaymentInstrumentsResponse>;
   deleteCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<boolean>;
   setDefaultCustomerPaymentInstrument(customerId: string, paymentInstrumentId: string): Promise<CustomerPaymentResponse>;
+  updateCustomerPaymentInstrument(customerProfile: CustomerProfile, paymentInstrumentInfo: PaymentInstrumentInfo): Promise<CustomerPaymentInstrumentResponse>;
   processPayment(clientReferenceCode: string, paymentInstrumentId: string, amount: number): Promise<PaymentTransactionResponse>;
   refundPayment(transactionId: string, amount: number): Promise<RefundPaymentResponse>;
   voidPayment(clientReferenceCode: string, transactionId: string): Promise<PaymentTransactionResponse>;
@@ -30,6 +31,14 @@ export interface CustomerProfile {
 export interface PaymentTokenInfo {
   paymentToken: string;
   isDefault: boolean;
+}
+
+export interface PaymentInstrumentInfo {
+  id: string;
+  paymentInstrumentId: string;
+  cardType: string;
+  cardExpirationMonth: string;
+  cardExpirationYear: string;
 }
 
 export interface PaymentTransactionResponse {
@@ -89,6 +98,7 @@ export interface PaymentInstrument {
     };
   };
   id: string;
+  object: string; // 'paymentInstrument'
   default: boolean;
   state: string; // 'ACTIVE'
   card: {
@@ -109,6 +119,7 @@ export interface PaymentInstrument {
     postalCode: string;
     country: string;
     email: string;
+    phoneNumber: string;
   };
   processingInformation: {
     billPaymentProgramEnabled: boolean;
@@ -145,7 +156,7 @@ export interface PaymentInstrument {
         };
       };
       metadata: {
-        creator: string;
+        creator: string; // 'ecfmg_faimer'
       };
     };
   };

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
@@ -7,6 +7,7 @@ import {
   CustomerProfile,
   PaymentTokenInfo,
   TransactionSearchResponse,
+  PaymentInstrumentInfo,
 } from '../services-seedwork-payment-cybersource-interfaces';
 import { Cybersource } from './index';
 
@@ -96,6 +97,11 @@ test.skip('cybersource: get customer payment instrument', async () => {
 
   expect(response).toBeDefined();
   expect(response.billTo).toBeDefined();
+  expect(response.id).toBe(paymentInstrumentId);
+  expect(response.instrumentIdentifier.id).toBe('7010000000188591111');
+  expect(response.card.expirationMonth).toEqual('09');
+  expect(response.card.expirationYear).toEqual('2024');
+  expect(response.card.type).toEqual('001');
   expect(response._embedded.instrumentIdentifier.card.number).toEqual('411111XXXXXX1111');
 });
 
@@ -122,6 +128,40 @@ test.skip('cybersource: set default customer payment instrument', async () => {
 
   expect(response).toBeDefined();
   expect(response._embedded.defaultPaymentInstrument.id).toBe(paymentInstrumentId);
+});
+
+test.skip('cybersource: update customer payment instrument', async () => {
+  const paymentInstrumentInfo: PaymentInstrumentInfo = {
+    id: '7010000000188591111',
+    paymentInstrumentId: '1D29441D8058A16EE063AF598E0A710A',
+    cardType: 'visa',
+    cardExpirationMonth: '12',
+    cardExpirationYear: '2024',
+  };
+
+  const customerProfile: CustomerProfile = {
+    customerId: '1CD4C5EE92E27A57E063AF598E0ACEC6',
+    billingFirstName: 'Jane',
+    billingLastName: 'Smith',
+    billingEmail: 'JSmith@cybs.com',
+    billingPhone: '1234567890',
+    billingAddressLine1: '321 Main St',
+    billingAddressLine2: 'Apt 1',
+    billingCity: 'San Francisco',
+    billingState: 'CA',
+    billingPostalCode: '94107',
+    billingCountry: 'US',
+  };
+
+  const response: CustomerPaymentInstrumentResponse = await cybersource.updateCustomerPaymentInstrument(customerProfile, paymentInstrumentInfo);
+
+  expect(response).toBeDefined();
+  expect(response.billTo.firstName).toBe('Jane');
+  expect(response.billTo.lastName).toBe('Smith');
+  expect(response.card.expirationMonth).toBe('12');
+  expect(response.card.expirationYear).toBe('2024');
+  expect(response.card.type).toBe('visa');
+  expect(response.state).toBe('ACTIVE');
 });
 
 test.skip('cybersource: process payment', async () => {

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -408,14 +408,14 @@ export class Cybersource implements CybersourceBase {
     let patchCustomerPaymentInstrumentRequest = new cybersource.PatchPaymentInstrumentRequest();
 
     // create a card object
-    let card = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentCard();
+    const card = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentCard();
     card.expirationMonth = paymentInstrumentInfo.cardExpirationMonth;
     card.expirationYear = paymentInstrumentInfo.cardExpirationYear;
     card.type = paymentInstrumentInfo.cardType;
     patchCustomerPaymentInstrumentRequest.card = card;
 
     // create a billTo object
-    let billTo = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentBillTo();
+    const billTo = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentBillTo();
     billTo.firstName = customerProfile.billingFirstName;
     billTo.lastName = customerProfile.billingLastName;
     billTo.email = customerProfile.billingEmail;
@@ -429,7 +429,7 @@ export class Cybersource implements CybersourceBase {
     patchCustomerPaymentInstrumentRequest.billTo = billTo;
 
     // create an instrumentIdentifier object
-    let paymentInstrumentIdentifier = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentInstrumentIdentifier();
+    const paymentInstrumentIdentifier = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentInstrumentIdentifier();
     paymentInstrumentIdentifier.id = paymentInstrumentInfo.id;
     patchCustomerPaymentInstrumentRequest.instrumentIdentifier = paymentInstrumentIdentifier;
 

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -10,6 +10,7 @@ import {
   CustomerPaymentInstrumentResponse,
   RefundPaymentResponse,
   PaymentTokenInfo,
+  PaymentInstrumentInfo,
   TransactionSearchResponse,
 } from '../services-seedwork-payment-cybersource-interfaces';
 
@@ -162,13 +163,13 @@ export class Cybersource implements CybersourceBase {
     tokenInformationObj.paymentInstrument = new cybersource.Ptsv2paymentsTokenInformationPaymentInstrument();
 
     // Ensure paymentTokenInfo and its properties are not null or undefined
-    if (paymentTokenInfo && paymentTokenInfo.paymentToken && typeof paymentTokenInfo.isDefault !== 'undefined') {
+    if (paymentTokenInfo?.paymentToken && typeof paymentTokenInfo?.isDefault !== 'undefined') {
       tokenInformationObj.transientTokenJwt = paymentTokenInfo.paymentToken;
       tokenInformationObj.paymentInstrument.default = paymentTokenInfo.isDefault; // Set the default payment instrument
     } else {
       // Handle the case where paymentTokenInfo or its properties are null or undefined
-console.error('Error: paymentTokenInfo or its required properties are null or undefined');
-throw new Error('paymentTokenInfo or its required properties are null or undefined');
+      console.error('Error: paymentTokenInfo or its required properties are null or undefined');
+      throw new Error('paymentTokenInfo or its required properties are null or undefined');
     }
 
     // create a new CreatePaymentRequest object
@@ -258,7 +259,7 @@ throw new Error('paymentTokenInfo or its required properties are null or undefin
     tokenInformation.paymentInstrument = new cybersource.Ptsv2paymentsTokenInformationPaymentInstrument();
 
     // Ensure paymentTokenInfo and its properties are not null or undefined
-    if (paymentTokenInfo && paymentTokenInfo.paymentToken && typeof paymentTokenInfo.isDefault !== 'undefined') {
+    if (paymentTokenInfo?.paymentToken && typeof paymentTokenInfo?.isDefault !== 'undefined') {
       tokenInformation.transientTokenJwt = paymentTokenInfo.paymentToken;
       tokenInformation.paymentInstrument.default = paymentTokenInfo.isDefault; // Set the default payment instrument
     } else {
@@ -378,7 +379,7 @@ throw new Error('paymentTokenInfo or its required properties are null or undefin
     let defaultPaymentInstrument = new cybersource.Tmsv2customersDefaultPaymentInstrument();
     defaultPaymentInstrument.id = paymentInstrumentId;
 
-    var customerUpdateRequest = new cybersource.PatchCustomerRequest();
+    let customerUpdateRequest = new cybersource.PatchCustomerRequest();
     customerUpdateRequest.defaultPaymentInstrument = defaultPaymentInstrument;
 
     return new Promise((resolve, reject) => {
@@ -387,6 +388,57 @@ throw new Error('paymentTokenInfo or its required properties are null or undefin
           resolve(data as CustomerPaymentResponse);
         } else {
           reject(new Error(error.message || 'Unknown error occurred in setting default customer payment instrument'));
+        }
+      });
+    });
+  }
+
+  /**
+   * Update a customer payment instrument in the Cybersource API
+   * @param {CustomerProfile} customerProfile The customer profile to be used for the payment instrument
+   * @param {PaymentInstrumentInfo} paymentInstrumentInfo The payment instrument information to be used for the payment instrument
+   * @returns {Promise<CustomerPaymentInstrumentResponse>} The response from the Cybersource API
+   * @throws {Error} If an error occurs in updating the customer payment instrument
+   * full details: https://developer.cybersource.com/api-reference-assets/index.html#token-management_customer-payment-instrument_update-a-customer-payment-instrument
+   * */
+  async updateCustomerPaymentInstrument(customerProfile: CustomerProfile, paymentInstrumentInfo: PaymentInstrumentInfo): Promise<CustomerPaymentInstrumentResponse> {
+    let options: { [key: string]: any } = {};
+    const instance = new cybersource.PaymentInstrumentApi(this._configObject, this._cybersourceClient);
+
+    let patchCustomerPaymentInstrumentRequest = new cybersource.PatchPaymentInstrumentRequest();
+
+    // create a card object
+    let card = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentCard();
+    card.expirationMonth = paymentInstrumentInfo.cardExpirationMonth;
+    card.expirationYear = paymentInstrumentInfo.cardExpirationYear;
+    card.type = paymentInstrumentInfo.cardType;
+    patchCustomerPaymentInstrumentRequest.card = card;
+
+    // create a billTo object
+    let billTo = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentBillTo();
+    billTo.firstName = customerProfile.billingFirstName;
+    billTo.lastName = customerProfile.billingLastName;
+    billTo.email = customerProfile.billingEmail;
+    billTo.phoneNumber = customerProfile.billingPhone;
+    billTo.address1 = customerProfile.billingAddressLine1;
+    billTo.address2 = customerProfile.billingAddressLine2;
+    billTo.locality = customerProfile.billingCity;
+    billTo.administrativeArea = customerProfile.billingState;
+    billTo.postalCode = customerProfile.billingPostalCode;
+    billTo.country = customerProfile.billingCountry;
+    patchCustomerPaymentInstrumentRequest.billTo = billTo;
+
+    // create an instrumentIdentifier object
+    let paymentInstrumentIdentifier = new cybersource.Tmsv2customersEmbeddedDefaultPaymentInstrumentInstrumentIdentifier();
+    paymentInstrumentIdentifier.id = paymentInstrumentInfo.id;
+    patchCustomerPaymentInstrumentRequest.instrumentIdentifier = paymentInstrumentIdentifier;
+
+    return new Promise((resolve, reject) => {
+      instance.patchPaymentInstrument(paymentInstrumentInfo.paymentInstrumentId, patchCustomerPaymentInstrumentRequest, options, function (error, data, response) {
+        if (!error) {
+          resolve(data as CustomerPaymentInstrumentResponse);
+        } else {
+          reject(new Error(error.message || 'Unknown error occurred in updating customer payment instrument'));
         }
       });
     });


### PR DESCRIPTION
This pull request adds the `updateCustomerPaymentInstrument` method to the `CybersourceBase` interface. This method allows for updating customer payment instrument information. The method takes a `CustomerProfile` object and a `PaymentInstrumentInfo` object as parameters. The `CustomerProfile` object contains the customer's billing information, while the `PaymentInstrumentInfo` object contains the updated payment instrument details. This addition enhances the functionality of the `CybersourceBase` interface and enables the updating of customer payment instrument information.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new method `updateCustomerPaymentInstrument` to the `CybersourceBase` interface, allowing for the updating of customer payment instrument information. It also includes the addition of the `PaymentInstrumentInfo` interface and a corresponding test case to validate the new functionality.

- **New Features**:
    - Added the `updateCustomerPaymentInstrument` method to the `CybersourceBase` interface, enabling the updating of customer payment instrument information.
- **Enhancements**:
    - Introduced the `PaymentInstrumentInfo` interface to encapsulate payment instrument details.
- **Tests**:
    - Added a test case for the `updateCustomerPaymentInstrument` method to ensure it correctly updates customer payment instrument information.

<!-- Generated by sourcery-ai[bot]: end summary -->