### PR TITLE
feat: adding get transactions data access changes into main

### DIFF
--- a/data-access/src/app/application-services/cases/violation-ticket/v1/violation-ticket.data.ts
+++ b/data-access/src/app/application-services/cases/violation-ticket/v1/violation-ticket.data.ts
@@ -1,9 +1,12 @@
+import { Types } from "mongoose";
 import { CosmosDataSource } from "../../../../data-sources/cosmos-data-source";
 import { ViolationTicketData } from "../../../../external-dependencies/datastore";
+import { PaymentTransactionsResult } from "../../../../external-dependencies/graphql-api";
 import { AppContext } from "../../../../init/app-context-builder";
 
 export interface ViolationTicketV1DataApi {
   getViolationTicketById(id: string): Promise<ViolationTicketData>;
+  getMemberPaymentTransactions(id: string): Promise<PaymentTransactionsResult[]>;
   // getServiceTicketsByCommunityId(communityId: string): Promise<ServiceTicketData[]>;
   // getServiceTicketsOpenByRequestor(memberId: string): Promise<ServiceTicketData[]>;
   // getServiceTicketsClosedByRequestor(memberId: string): Promise<ServiceTicketData[]>;
@@ -16,5 +19,46 @@ export class ViolationTicketV1DataApiImpl
   async getViolationTicketById(id: string): Promise<ViolationTicketData> {
     let dbData = await this.model.findById(id).populate(['community', 'property', 'requestor', 'assignedTo']).exec();
     return dbData;
+  }
+
+  async getMemberPaymentTransactions(id: string): Promise<PaymentTransactionsResult[]> {
+    let transactions = await this.model
+      .aggregate([
+        {
+          $match: {
+            assignedTo: new Types.ObjectId(id),
+          },
+        },
+        {
+          $unwind: {
+            path: '$paymentTransactions',
+            preserveNullAndEmptyArrays: false,
+          },
+        },
+        {
+          $replaceRoot: {
+            newRoot: '$paymentTransactions',
+          },
+        },
+        {
+          $project: {
+            transactionId: 1,
+            status: 1,
+            type: 1,
+            description: 1,
+            successTimestamp: 1,
+            isSuccess: 1,
+            amount: '$amountDetails.amount',
+            currency: '$amountDetails.currency',
+          },
+        },
+        {
+          $sort: {
+            successTimestamp: -1,
+          },
+        },
+      ])
+      .exec();
+    return transactions.map((transaction) => ({ id: transaction._id, ...transaction }));
   }
 }

--- a/data-access/src/graphql/schema/builder/generated.ts
+++ b/data-access/src/graphql/schema/builder/generated.ts
@@ -910,6 +910,19 @@ export type PaymentTransactionError = {
   timestamp?: Maybe<Scalars['DateTime']>;
 };
 
+export type PaymentTransactionsResult = {
+  __typename?: 'PaymentTransactionsResult';
+  amount?: Maybe<Scalars['Float']>;
+  currency?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  isSuccess?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
+  successTimestamp?: Maybe<Scalars['DateTime']>;
+  transactionId?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+};
+
 export type PermissionsInput = {
   communityPermissions: CommunityPermissionsInput;
   propertyPermissions: PropertyPermissionsInput;
@@ -1124,6 +1137,7 @@ export type Query = {
   userCurrent?: Maybe<CurrentUser>;
   users?: Maybe<Array<Maybe<User>>>;
   violationTicket?: Maybe<ViolationTicket>;
+  violationTicketPaymentTransactions?: Maybe<Array<Maybe<PaymentTransactionsResult>>>;
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1507,6 +1521,7 @@ export type Transaction = {
   __typename?: 'Transaction';
   amountDetails?: Maybe<AmountDetails>;
   clientReferenceCode?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
   error?: Maybe<PaymentTransactionError>;
   id: Scalars['ObjectID'];
   isSuccess?: Maybe<Scalars['Boolean']>;
@@ -1515,6 +1530,7 @@ export type Transaction = {
   successTimestamp?: Maybe<Scalars['DateTime']>;
   transactionId?: Maybe<Scalars['String']>;
   transactionTime?: Maybe<Scalars['DateTime']>;
+  type?: Maybe<Scalars['String']>;
 };
 
 export type User = MongoBase & {
@@ -1859,6 +1875,7 @@ export type ResolversTypes = ResolversObject<{
   PaymentInstrument: ResolverTypeWrapper<PaymentInstrument>;
   PaymentInstrumentResult: ResolverTypeWrapper<PaymentInstrumentResult>;
   PaymentTransactionError: ResolverTypeWrapper<PaymentTransactionError>;
+  PaymentTransactionsResult: ResolverTypeWrapper<PaymentTransactionsResult>;
   PermissionsInput: PermissionsInput;
   PhoneNumber: ResolverTypeWrapper<Scalars['PhoneNumber']>;
   Point: ResolverTypeWrapper<Point>;
@@ -2091,6 +2108,7 @@ export type ResolversParentTypes = ResolversObject<{
   PaymentInstrument: PaymentInstrument;
   PaymentInstrumentResult: PaymentInstrumentResult;
   PaymentTransactionError: PaymentTransactionError;
+  PaymentTransactionsResult: PaymentTransactionsResult;
   PermissionsInput: PermissionsInput;
   PhoneNumber: Scalars['PhoneNumber'];
   Point: Point;
@@ -2896,6 +2914,22 @@ export type PaymentTransactionErrorResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PaymentTransactionsResultResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['PaymentTransactionsResult'] = ResolversParentTypes['PaymentTransactionsResult'],
+> = ResolversObject<{
+  amount?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  currency?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
+  isSuccess?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  successTimestamp?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  transactionId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export interface PhoneNumberScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['PhoneNumber'], any> {
   name: 'PhoneNumber';
 }
@@ -3087,6 +3121,7 @@ export type QueryResolvers<ContextType = GraphqlContext, ParentType extends Reso
   userCurrent?: Resolver<Maybe<ResolversTypes['CurrentUser']>, ParentType, ContextType>;
   users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   violationTicket?: Resolver<Maybe<ResolversTypes['ViolationTicket']>, ParentType, ContextType, RequireFields<QueryViolationTicketArgs, 'id'>>;
+  violationTicketPaymentTransactions?: Resolver<Maybe<Array<Maybe<ResolversTypes['PaymentTransactionsResult']>>>, ParentType, ContextType>;
 }>;
 
 export interface RgbScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['RGB'], any> {
@@ -3321,6 +3356,7 @@ export type TransactionResolvers<
 > = ResolversObject<{
   amountDetails?: Resolver<Maybe<ResolversTypes['AmountDetails']>, ParentType, ContextType>;
   clientReferenceCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['PaymentTransactionError']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
   isSuccess?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
@@ -3329,6 +3365,7 @@ export type TransactionResolvers<
   successTimestamp?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   transactionId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   transactionTime?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3523,6 +3560,7 @@ export type Resolvers<ContextType = GraphqlContext> = ResolversObject<{
   PaymentInstrument?: PaymentInstrumentResolvers<ContextType>;
   PaymentInstrumentResult?: PaymentInstrumentResultResolvers<ContextType>;
   PaymentTransactionError?: PaymentTransactionErrorResolvers<ContextType>;
+  PaymentTransactionsResult?: PaymentTransactionsResultResolvers<ContextType>;
   PhoneNumber?: GraphQLScalarType;
   Point?: PointResolvers<ContextType>;
   Port?: GraphQLScalarType;

--- a/data-access/src/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/graphql/schema/builder/graphql.schema.json
@@ -7295,6 +7295,129 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "PaymentTransactionsResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "amount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currency",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isSuccess",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "successTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "transactionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "PermissionsInput",
         "description": null,
@@ -9893,6 +10016,22 @@
               "kind": "OBJECT",
               "name": "ViolationTicket",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "violationTicketPaymentTransactions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PaymentTransactionsResult",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12668,6 +12807,18 @@
             "deprecationReason": null
           },
           {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "error",
             "description": null,
             "args": [],
@@ -12762,6 +12913,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,

--- a/data-access/src/graphql/schema/types/violation-ticket.graphql
+++ b/data-access/src/graphql/schema/types/violation-ticket.graphql
@@ -38,6 +38,7 @@ type ViolationTicketV1Message {
 
 extend type Query {
   violationTicket(id: ObjectID!): ViolationTicket
+  violationTicketPaymentTransactions: [PaymentTransactionsResult]
 }
 
 input ViolationTicketCreateInput {
@@ -115,11 +116,25 @@ type Transaction {
   clientReferenceCode: String
   amountDetails: AmountDetails
   status: String
+  type: String
+  description: String
   reconciliationId: String
   isSuccess: Boolean
   transactionTime: DateTime
   successTimestamp: DateTime
   error: PaymentTransactionError
+}
+
+type PaymentTransactionsResult {
+  id: ObjectID!
+  transactionId: String
+  amount: Float
+  currency: String
+  status: String
+  isSuccess: Boolean
+  description: String
+  type: String
+  successTimestamp: DateTime
 }
 
 type AmountDetails {

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -908,6 +908,19 @@ export type PaymentTransactionError = {
   timestamp?: Maybe<Scalars['DateTime']>;
 };
 
+export type PaymentTransactionsResult = {
+  __typename?: 'PaymentTransactionsResult';
+  amount?: Maybe<Scalars['Float']>;
+  currency?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  isSuccess?: Maybe<Scalars['Boolean']>;
+  status?: Maybe<Scalars['String']>;
+  successTimestamp?: Maybe<Scalars['DateTime']>;
+  transactionId?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+};
+
 export type PermissionsInput = {
   communityPermissions: CommunityPermissionsInput;
   propertyPermissions: PropertyPermissionsInput;
@@ -1122,6 +1135,7 @@ export type Query = {
   userCurrent?: Maybe<CurrentUser>;
   users?: Maybe<Array<Maybe<User>>>;
   violationTicket?: Maybe<ViolationTicket>;
+  violationTicketPaymentTransactions?: Maybe<Array<Maybe<PaymentTransactionsResult>>>;
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1505,6 +1519,7 @@ export type Transaction = {
   __typename?: 'Transaction';
   amountDetails?: Maybe<AmountDetails>;
   clientReferenceCode?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
   error?: Maybe<PaymentTransactionError>;
   id: Scalars['ObjectID'];
   isSuccess?: Maybe<Scalars['Boolean']>;
@@ -1513,6 +1528,7 @@ export type Transaction = {
   successTimestamp?: Maybe<Scalars['DateTime']>;
   transactionId?: Maybe<Scalars['String']>;
   transactionTime?: Maybe<Scalars['DateTime']>;
+  type?: Maybe<Scalars['String']>;
 };
 
 export type User = MongoBase & {


### PR DESCRIPTION
This pull request adds changes to the data access layer for retrieving payment transactions. It includes a new query `violationTicketPaymentTransactions` that returns an array of `PaymentTransactionsResult` objects. The implementation uses MongoDB aggregation to fetch the transactions for a specific member and sorts them by the success timestamp in descending order.