### PR TITLE
Added expirationMonth and expirationYear details in payment instrument response

### DIFF
--- a/data-access/src/app/application-services/member/member.payment.ts
+++ b/data-access/src/app/application-services/member/member.payment.ts
@@ -76,6 +76,8 @@ export class PaymentCybersourceApiImpl extends PaymentDataSource<AppContext> imp
         cardType: paymentInstrument?.card?.type,
         paymentInstrumentId: paymentInstrument?.id,
         isDefault: paymentInstrument?.default,
+        expirationMonth: paymentInstrument?.card?.expirationMonth,
+        expirationYear: paymentInstrument?.card?.expirationYear,
       };
     });
     return response;

--- a/data-access/src/graphql/schema/builder/generated.ts
+++ b/data-access/src/graphql/schema/builder/generated.ts
@@ -893,6 +893,8 @@ export type PaymentInstrument = {
   __typename?: 'PaymentInstrument';
   cardNumber?: Maybe<Scalars['String']>;
   cardType?: Maybe<Scalars['String']>;
+  expirationMonth?: Maybe<Scalars['String']>;
+  expirationYear?: Maybe<Scalars['String']>;
   isDefault?: Maybe<Scalars['Boolean']>;
   paymentInstrumentId?: Maybe<Scalars['String']>;
 };
@@ -2890,6 +2892,8 @@ export type PaymentInstrumentResolvers<
 > = ResolversObject<{
   cardNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   cardType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  expirationMonth?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  expirationYear?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   paymentInstrumentId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/data-access/src/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/graphql/schema/builder/graphql.schema.json
@@ -7175,6 +7175,30 @@
             "deprecationReason": null
           },
           {
+            "name": "expirationMonth",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expirationYear",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isDefault",
             "description": null,
             "args": [],

--- a/data-access/src/graphql/schema/types/member.graphql
+++ b/data-access/src/graphql/schema/types/member.graphql
@@ -160,6 +160,8 @@ type PaymentInstrument {
   paymentInstrumentId: String
   cardNumber: String # Masked card number
   isDefault: Boolean
+  expirationYear: String
+  expirationMonth: String
 }
 
 type PaymentInstrumentResult {

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -891,6 +891,8 @@ export type PaymentInstrument = {
   __typename?: 'PaymentInstrument';
   cardNumber?: Maybe<Scalars['String']>;
   cardType?: Maybe<Scalars['String']>;
+  expirationMonth?: Maybe<Scalars['String']>;
+  expirationYear?: Maybe<Scalars['String']>;
   isDefault?: Maybe<Scalars['Boolean']>;
   paymentInstrumentId?: Maybe<Scalars['String']>;
 };


### PR DESCRIPTION
Added expirationMonth and expirationYear details in payment instrument response

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces new fields, expirationMonth and expirationYear, to the PaymentInstrument type in the GraphQL schema. These fields are now included in the payment instrument response, allowing clients to access the expiration details of payment instruments.

- **New Features**:
    - Added expirationMonth and expirationYear fields to the PaymentInstrument type in the GraphQL schema.

<!-- Generated by sourcery-ai[bot]: end summary -->