### PR TITLE
Refactor activity detail, violation-ticket, transactions setters to accept string values

### DIFF
--- a/data-access/src/app/domain/contexts/cases/service-ticket/v1/activity-detail.ts
+++ b/data-access/src/app/domain/contexts/cases/service-ticket/v1/activity-detail.ts
@@ -34,11 +34,11 @@ export class ActivityDetail extends Entity<ActivityDetailProps> implements Activ
 
   // using set from TS 5.1
 
-  set ActivityType(activityTypeCode: ValueObjects.ActivityTypeCode) {
-    this.props.activityType = activityTypeCode.valueOf();
+  set ActivityType(activityTypeCode: string) {
+    this.props.activityType = new ValueObjects.ActivityTypeCode(activityTypeCode).valueOf();
   }
-  set ActivityDescription(activityDescription: ValueObjects.Description) {
-    this.props.activityDescription = activityDescription.valueOf();
+  set ActivityDescription(activityDescription: string) {
+    this.props.activityDescription = new ValueObjects.Description(activityDescription).valueOf();
   }
 
   set ActivityBy(activityBy: MemberEntityReference) {

--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
@@ -34,11 +34,11 @@ export class ActivityDetail extends Entity<ActivityDetailProps> implements Activ
 
   // using set from TS 5.1
 
-  set ActivityType(activityTypeCode: ValueObjects.ActivityTypeCode) {
-    this.props.activityType = activityTypeCode.valueOf();
+  set ActivityType(activityTypeCode: string) {
+    this.props.activityType = new ValueObjects.ActivityTypeCode(activityTypeCode).valueOf();
   }
-  set ActivityDescription(activityDescription: ValueObjects.Description) {
-    this.props.activityDescription = activityDescription.valueOf();
+  set ActivityDescription(activityDescription: string) {
+    this.props.activityDescription = new ValueObjects.Description(activityDescription).valueOf();
   }
 
   set ActivityBy(activityBy: MemberEntityReference) {

--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/transaction.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/transaction.ts
@@ -81,12 +81,6 @@ export class Transaction extends Entity<TransactionProps> implements Transaction
     this.props.clientReferenceCode = clientReferenceCode.valueOf();
   }
 
-  // set AmountDetails(amountDetails: ValueObjects.AmountDetails) {
-  //   this.props.amountDetails.amount = amountDetails.amount.valueOf();
-  //   this.props.amountDetails.authorizedAmount = amountDetails.authorizedAmount.valueOf();
-  //   this.props.amountDetails.currency = amountDetails.currency.valueOf();
-  // }
-
   set Amount(amount: ValueObjects.AmountDetails["amount"]) {
     this.props.amountDetails.amount = amount.valueOf();
   }
@@ -98,20 +92,20 @@ export class Transaction extends Entity<TransactionProps> implements Transaction
   set Currency(currency: ValueObjects.AmountDetails["currency"]) {
     this.props.amountDetails.currency = currency.valueOf();
   }
-  set Description(description: ValueObjects.Description) {
-    this.props.description = description.valueOf();
+  set Description(description: string) {
+    this.props.description = new ValueObjects.Description(description).valueOf();
   }
 
-  set Type(type: ValueObjects.Type) {
-    this.props.type = type.valueOf();
+  set Type(type: string) {
+    this.props.type = new ValueObjects.Type(type).valueOf();
   }
 
-  set Status(status: ValueObjects.Status) {
-    this.props.status = status.valueOf();
+  set Status(status: string) {
+    this.props.status = new ValueObjects.Status(status).valueOf();
   }
 
-  set ReconciliationId(reconciliationId: ValueObjects.ReconciliationId) {
-    this.props.reconciliationId = reconciliationId.valueOf();
+  set ReconciliationId(reconciliationId: string) {
+    this.props.reconciliationId = new ValueObjects.ReconciliationId(reconciliationId).valueOf();
   }
 
   set IsSuccess(isSuccess: boolean) {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the setters in the Transaction, ActivityDetail, and ViolationTicket classes to accept string values instead of specific ValueObjects. This change simplifies the interface for setting these properties.

- **Enhancements**:
    - Refactored setters in Transaction, ActivityDetail, and ViolationTicket classes to accept string values instead of specific ValueObjects.

<!-- Generated by sourcery-ai[bot]: end summary -->