### PR TITLE
Added bill info, state and id fields in payment instrument call

### DIFF
--- a/data-access/src/app/application-services/member/member.payment.ts
+++ b/data-access/src/app/application-services/member/member.payment.ts
@@ -78,6 +78,9 @@ export class PaymentCybersourceApiImpl extends PaymentDataSource<AppContext> imp
         isDefault: paymentInstrument?.default,
         expirationMonth: paymentInstrument?.card?.expirationMonth,
         expirationYear: paymentInstrument?.card?.expirationYear,
+        id: paymentInstrument?.instrumentIdentifier?.id,
+        state: paymentInstrument?.state,
+        billTo: paymentInstrument?.billTo
       };
     });
     return response;

--- a/data-access/src/routes/http/graphql/schema/builder/generated.ts
+++ b/data-access/src/routes/http/graphql/schema/builder/generated.ts
@@ -889,14 +889,31 @@ export type MutationStatus = {
   success: Scalars['Boolean'];
 };
 
+export type PaymentBillingInfo = {
+  __typename?: 'PaymentBillingInfo';
+  address1: Scalars['String'];
+  address2?: Maybe<Scalars['String']>;
+  administrativeArea: Scalars['String'];
+  country: Scalars['String'];
+  email: Scalars['String'];
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  locality: Scalars['String'];
+  phoneNumber: Scalars['String'];
+  postalCode: Scalars['String'];
+};
+
 export type PaymentInstrument = {
   __typename?: 'PaymentInstrument';
+  billTo?: Maybe<PaymentBillingInfo>;
   cardNumber?: Maybe<Scalars['String']>;
   cardType?: Maybe<Scalars['String']>;
   expirationMonth?: Maybe<Scalars['String']>;
   expirationYear?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
   isDefault?: Maybe<Scalars['Boolean']>;
   paymentInstrumentId?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
 };
 
 export type PaymentInstrumentResult = {
@@ -1874,6 +1891,7 @@ export type ResolversTypes = ResolversObject<{
   NonPositiveFloat: ResolverTypeWrapper<Scalars['NonPositiveFloat']>;
   NonPositiveInt: ResolverTypeWrapper<Scalars['NonPositiveInt']>;
   ObjectID: ResolverTypeWrapper<Scalars['ObjectID']>;
+  PaymentBillingInfo: ResolverTypeWrapper<PaymentBillingInfo>;
   PaymentInstrument: ResolverTypeWrapper<PaymentInstrument>;
   PaymentInstrumentResult: ResolverTypeWrapper<PaymentInstrumentResult>;
   PaymentTransactionError: ResolverTypeWrapper<PaymentTransactionError>;
@@ -2107,6 +2125,7 @@ export type ResolversParentTypes = ResolversObject<{
   NonPositiveFloat: Scalars['NonPositiveFloat'];
   NonPositiveInt: Scalars['NonPositiveInt'];
   ObjectID: Scalars['ObjectID'];
+  PaymentBillingInfo: PaymentBillingInfo;
   PaymentInstrument: PaymentInstrument;
   PaymentInstrumentResult: PaymentInstrumentResult;
   PaymentTransactionError: PaymentTransactionError;
@@ -2886,16 +2905,36 @@ export interface ObjectIdScalarConfig extends GraphQLScalarTypeConfig<ResolversT
   name: 'ObjectID';
 }
 
+export type PaymentBillingInfoResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['PaymentBillingInfo'] = ResolversParentTypes['PaymentBillingInfo'],
+> = ResolversObject<{
+  address1?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  address2?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  administrativeArea?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  country?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  firstName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lastName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  locality?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  phoneNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  postalCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type PaymentInstrumentResolvers<
   ContextType = GraphqlContext,
   ParentType extends ResolversParentTypes['PaymentInstrument'] = ResolversParentTypes['PaymentInstrument'],
 > = ResolversObject<{
+  billTo?: Resolver<Maybe<ResolversTypes['PaymentBillingInfo']>, ParentType, ContextType>;
   cardNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   cardType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   expirationMonth?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   expirationYear?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   paymentInstrumentId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3561,6 +3600,7 @@ export type Resolvers<ContextType = GraphqlContext> = ResolversObject<{
   NonPositiveFloat?: GraphQLScalarType;
   NonPositiveInt?: GraphQLScalarType;
   ObjectID?: GraphQLScalarType;
+  PaymentBillingInfo?: PaymentBillingInfoResolvers<ContextType>;
   PaymentInstrument?: PaymentInstrumentResolvers<ContextType>;
   PaymentInstrumentResult?: PaymentInstrumentResultResolvers<ContextType>;
   PaymentTransactionError?: PaymentTransactionErrorResolvers<ContextType>;

--- a/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
@@ -7147,9 +7147,188 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PaymentBillingInfo",
+        "description": null,
+        "fields": [
+          {
+            "name": "address1",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "address2",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "administrativeArea",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locality",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "phoneNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postalCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PaymentInstrument",
         "description": null,
         "fields": [
+          {
+            "name": "billTo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PaymentBillingInfo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "cardNumber",
             "description": null,
@@ -7199,6 +7378,18 @@
             "deprecationReason": null
           },
           {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isDefault",
             "description": null,
             "args": [],
@@ -7212,6 +7403,18 @@
           },
           {
             "name": "paymentInstrumentId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
             "description": null,
             "args": [],
             "type": {

--- a/data-access/src/routes/http/graphql/schema/types/member.graphql
+++ b/data-access/src/routes/http/graphql/schema/types/member.graphql
@@ -172,10 +172,10 @@ type PaymentBillingInfo{
   lastName: String!
   address1: String!
   address2: String
-  locality: String!
-  administrativeArea: String!
-  postalCode: String!
-  country: String!
+  locality: String! # The city of billing address
+  administrativeArea: String! # The region or state of the billing address
+  postalCode: String! # The postal code of the billing address
+  country: String! # The country of the billing address
   email: String!
   phoneNumber: String!
 }

--- a/data-access/src/routes/http/graphql/schema/types/member.graphql
+++ b/data-access/src/routes/http/graphql/schema/types/member.graphql
@@ -162,6 +162,22 @@ type PaymentInstrument {
   isDefault: Boolean
   expirationYear: String
   expirationMonth: String
+  id: String
+  state: String
+  billTo: PaymentBillingInfo
+}
+
+type PaymentBillingInfo{
+  firstName: String!
+  lastName: String!
+  address1: String!
+  address2: String
+  locality: String!
+  administrativeArea: String!
+  postalCode: String!
+  country: String!
+  email: String!
+  phoneNumber: String!
 }
 
 type PaymentInstrumentResult {

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -887,14 +887,31 @@ export type MutationStatus = {
   success: Scalars['Boolean'];
 };
 
+export type PaymentBillingInfo = {
+  __typename?: 'PaymentBillingInfo';
+  address1: Scalars['String'];
+  address2?: Maybe<Scalars['String']>;
+  administrativeArea: Scalars['String'];
+  country: Scalars['String'];
+  email: Scalars['String'];
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  locality: Scalars['String'];
+  phoneNumber: Scalars['String'];
+  postalCode: Scalars['String'];
+};
+
 export type PaymentInstrument = {
   __typename?: 'PaymentInstrument';
+  billTo?: Maybe<PaymentBillingInfo>;
   cardNumber?: Maybe<Scalars['String']>;
   cardType?: Maybe<Scalars['String']>;
   expirationMonth?: Maybe<Scalars['String']>;
   expirationYear?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
   isDefault?: Maybe<Scalars['Boolean']>;
   paymentInstrumentId?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
 };
 
 export type PaymentInstrumentResult = {


### PR DESCRIPTION
Added bill info, state and id fields in member payment instrument resolver

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds new fields to the 'PaymentInstrument' type in the GraphQL schema, including billing information, state, and ID. It also introduces a new 'PaymentBillingInfo' type to encapsulate detailed billing information.

- **New Features**:
    - Added 'PaymentBillingInfo' type to the GraphQL schema, including fields for address, administrative area, country, email, first name, last name, locality, phone number, and postal code.
    - Introduced 'billTo', 'id', and 'state' fields to the 'PaymentInstrument' type in the GraphQL schema.

<!-- Generated by sourcery-ai[bot]: end summary -->