### PR TITLE
nn-staff-graphql

### DIFF
--- a/data-access/src/app/application-services/roles/staff-role/staff-role.domain.ts
+++ b/data-access/src/app/application-services/roles/staff-role/staff-role.domain.ts
@@ -2,14 +2,14 @@ import { DomainDataSource } from "../../../data-sources/domain-data-source";
 import { StaffRole } from "../../../domain/contexts/community/roles/staff-role/staff-role";
 import { ReadOnlyDomainVisa } from "../../../domain/domain.visa";
 import { StaffRoleData } from "../../../external-dependencies/datastore";
-import { StaffRoleDomainAdapter, CommunityConverter, StaffRoleConverter, StaffRoleRepository } from "../../../external-dependencies/domain";
-import { RoleAddInput, RoleDeleteAndReassignInput, RoleUpdateInput } from "../../../external-dependencies/graphql-api";
+import { StaffRoleDomainAdapter, StaffRoleConverter, StaffRoleRepository } from "../../../external-dependencies/domain";
+import { StaffRoleAddInput, StaffRoleDeleteAndReassignInput, StaffRoleUpdateInput } from "../../../external-dependencies/graphql-api";
 import { AppContext } from "../../../init/app-context-builder";
 
 export interface StaffRoleDomainApi {
-  roleAdd(input: RoleAddInput) : Promise<StaffRoleData>;
-  // roleUpdate(input: RoleUpdateInput) : Promise<RoleData>;
-  // roleDeleteAndReassign(input: RoleDeleteAndReassignInput) : Promise<RoleData>;
+  roleAdd(input: StaffRoleAddInput) : Promise<StaffRoleData>;
+  roleUpdate(input: StaffRoleUpdateInput) : Promise<StaffRoleData>;
+  roleDeleteAndReassign(input: StaffRoleDeleteAndReassignInput) : Promise<StaffRoleData>;
 }
 
 type PropType = StaffRoleDomainAdapter;
@@ -20,80 +20,79 @@ export class StaffRoleDomainApiImpl
   extends DomainDataSource<AppContext, StaffRoleData, PropType, DomainType, RepoType>
   implements StaffRoleDomainApi {
 
-  async roleAdd(input: RoleAddInput): Promise<StaffRoleData> {
-    console.log(`roleAdd`, this.context.verifiedUser);
-    if (this.context.verifiedUser.openIdConfigKey !== 'AccountPortal') {
-      throw new Error('Unauthorized:roleCreate');
+  async roleAdd(input: StaffRoleAddInput): Promise<StaffRoleData> {
+    console.log(`staffRoleAdd`, this.context.verifiedUser);
+    if (this.context.verifiedUser.openIdConfigKey !== 'StaffPortal') {
+      throw new Error('Unauthorized:staffRoleCreate');
     }
 
-    let roleToReturn: StaffRoleData;
+    let staffRoleToReturn: StaffRoleData;
 
     await this.withTransaction(async (repo) => {
-      let roleDo = await repo.getNewInstance(input.roleName);
+      let staffRoleDo = await repo.getNewInstance(input.roleName);
 
       // this code is not correct, need to create new graphql inputs for staff roles
-      roleDo.permissions.communityPermissions.canManageStaffRolesAndPermissions = (input.permissions.communityPermissions.canManageRolesAndPermissions);
-      roleDo.permissions.communityPermissions.canManageAllCommunities = (input.permissions.communityPermissions.canManageCommunitySettings);
-      roleDo.permissions.communityPermissions.canDeleteCommunities = (input.permissions.communityPermissions.canManageSiteContent);
-      roleDo.permissions.communityPermissions.canChangeCommunityOwner = (input.permissions.communityPermissions.canManageMembers);
-      roleDo.permissions.communityPermissions.canReIndexSearchCollections = (input.permissions.communityPermissions.canEditOwnMemberProfile);
+      staffRoleDo.permissions.communityPermissions.canManageStaffRolesAndPermissions = (input.permissions.communityPermissions.canManageStaffRolesAndPermissions);
+      staffRoleDo.permissions.communityPermissions.canManageAllCommunities = (input.permissions.communityPermissions.canManageAllCommunities);
+      staffRoleDo.permissions.communityPermissions.canDeleteCommunities = (input.permissions.communityPermissions.canDeleteCommunities);
+      staffRoleDo.permissions.communityPermissions.canChangeCommunityOwner = (input.permissions.communityPermissions.canChangeCommunityOwner);
+      staffRoleDo.permissions.communityPermissions.canReIndexSearchCollections = (input.permissions.communityPermissions.canReIndexSearchCollections);
 
-      roleToReturn = new StaffRoleConverter().toPersistence(await repo.save(roleDo));
+      staffRoleToReturn = new StaffRoleConverter().toPersistence(await repo.save(staffRoleDo));
+    });
+    return staffRoleToReturn;
+  }
+
+  async roleUpdate(input: StaffRoleUpdateInput): Promise<StaffRoleData> {
+    console.log(`staffRoleUpdate`, this.context.verifiedUser);
+    if (this.context.verifiedUser.openIdConfigKey !== 'StaffPortal') {
+      throw new Error('Unauthorized:staffRoleUpdate');
+    }
+
+    let staffRoleToReturn: StaffRoleData;
+    await this.withTransaction(async (repo) => {
+      let staffRoleDo = await repo.getById(input.id);
+
+      staffRoleDo.roleName = (input.roleName);
+
+      staffRoleDo.permissions.communityPermissions.canManageStaffRolesAndPermissions = (input.permissions.communityPermissions.canManageStaffRolesAndPermissions);
+      staffRoleDo.permissions.communityPermissions.canManageAllCommunities = (input.permissions.communityPermissions.canManageAllCommunities);
+      staffRoleDo.permissions.communityPermissions.canDeleteCommunities = (input.permissions.communityPermissions.canDeleteCommunities);
+      staffRoleDo.permissions.communityPermissions.canChangeCommunityOwner = (input.permissions.communityPermissions.canChangeCommunityOwner);
+      staffRoleDo.permissions.communityPermissions.canReIndexSearchCollections = (input.permissions.communityPermissions.canReIndexSearchCollections);
+
+      // staffRoleDo.permissions.propertyPermissions.canManageProperties = (input.permissions.propertyPermissions.canManageProperties);
+      // staffRoleDo.permissions.propertyPermissions.canEditOwnProperty = (input.permissions.propertyPermissions.canEditOwnProperty);
+
+      // staffRoleDo.permissions.serviceTicketPermissions.canCreateTickets = (input.permissions.serviceTicketPermissions.canCreateTickets);
+      // staffRoleDo.permissions.serviceTicketPermissions.canManageTickets = (input.permissions.serviceTicketPermissions.canManageTickets);
+      // staffRoleDo.permissions.serviceTicketPermissions.canAssignTickets = (input.permissions.serviceTicketPermissions.canAssignTickets);
+      // staffRoleDo.permissions.serviceTicketPermissions.canWorkOnTickets = (input.permissions.serviceTicketPermissions.canWorkOnTickets);
+
+      // staffRoleDo.permissions.violationTicketPermissions.canAssignTickets = (input.permissions.violationTicketPermissions.canAssignTickets);
+      // staffRoleDo.permissions.violationTicketPermissions.canCreateTickets = (input.permissions.violationTicketPermissions.canCreateTickets);
+      // staffRoleDo.permissions.violationTicketPermissions.canManageTickets = (input.permissions.violationTicketPermissions.canManageTickets);
+      // staffRoleDo.permissions.violationTicketPermissions.canWorkOnTickets = (input.permissions.violationTicketPermissions.canWorkOnTickets);
+
+      staffRoleToReturn = new StaffRoleConverter().toPersistence(await repo.save(staffRoleDo));
+    });
+    return staffRoleToReturn;
+  }
+
+  async roleDeleteAndReassign(input: StaffRoleDeleteAndReassignInput): Promise<StaffRoleData> {
+    console.log(`roleDeleteAndReassign`, this.context.verifiedUser);
+    if (this.context.verifiedUser.openIdConfigKey !== 'AccountPortal') {
+      throw new Error('Unauthorized:roleDeleteAndReassign');
+    }
+
+    let mongoNewRole = await this.context.applicationServices.roles.staffRole.dataApi.getRoleById(input.roleToReassignTo);
+    let newRoleDo = new StaffRoleConverter().toDomain(mongoNewRole, { domainVisa: ReadOnlyDomainVisa.GetInstance() });
+    let roleToReturn: StaffRoleData;
+    await this.withTransaction(async (repo) => {
+      let staffRoleDo = await repo.getById(input.roleToDelete);
+      staffRoleDo.deleteAndReassignTo = (newRoleDo);
+      roleToReturn = new StaffRoleConverter().toPersistence(await repo.save(staffRoleDo));
     });
     return roleToReturn;
   }
-
-  // async roleUpdate(input: RoleUpdateInput): Promise<RoleData> {
-  //   console.log(`roleUpdate`, this.context.verifiedUser);
-  //   if (this.context.verifiedUser.openIdConfigKey !== 'AccountPortal') {
-  //     throw new Error('Unauthorized:roleUpdate');
-  //   }
-
-  //   let roleToReturn: RoleData;
-  //   await this.withTransaction(async (repo) => {
-  //     let roleDo = await repo.getById(input.id);
-
-  //     roleDo.roleName = (input.roleName);
-
-  //     roleDo.permissions.communityPermissions.canManageRolesAndPermissions = (input.permissions.communityPermissions.canManageRolesAndPermissions);
-  //     roleDo.permissions.communityPermissions.canManageCommunitySettings = (input.permissions.communityPermissions.canManageCommunitySettings);
-  //     roleDo.permissions.communityPermissions.canManageSiteContent = (input.permissions.communityPermissions.canManageSiteContent);
-  //     roleDo.permissions.communityPermissions.canManageMembers = (input.permissions.communityPermissions.canManageMembers);
-  //     roleDo.permissions.communityPermissions.canEditOwnMemberProfile = (input.permissions.communityPermissions.canEditOwnMemberProfile);
-  //     roleDo.permissions.communityPermissions.canEditOwnMemberAccounts = (input.permissions.communityPermissions.canEditOwnMemberAccounts);
-
-  //     roleDo.permissions.propertyPermissions.canManageProperties = (input.permissions.propertyPermissions.canManageProperties);
-  //     roleDo.permissions.propertyPermissions.canEditOwnProperty = (input.permissions.propertyPermissions.canEditOwnProperty);
-
-  //     roleDo.permissions.serviceTicketPermissions.canCreateTickets = (input.permissions.serviceTicketPermissions.canCreateTickets);
-  //     roleDo.permissions.serviceTicketPermissions.canManageTickets = (input.permissions.serviceTicketPermissions.canManageTickets);
-  //     roleDo.permissions.serviceTicketPermissions.canAssignTickets = (input.permissions.serviceTicketPermissions.canAssignTickets);
-  //     roleDo.permissions.serviceTicketPermissions.canWorkOnTickets = (input.permissions.serviceTicketPermissions.canWorkOnTickets);
-
-  //     roleDo.permissions.violationTicketPermissions.canAssignTickets = (input.permissions.violationTicketPermissions.canAssignTickets);
-  //     roleDo.permissions.violationTicketPermissions.canCreateTickets = (input.permissions.violationTicketPermissions.canCreateTickets);
-  //     roleDo.permissions.violationTicketPermissions.canManageTickets = (input.permissions.violationTicketPermissions.canManageTickets);
-  //     roleDo.permissions.violationTicketPermissions.canWorkOnTickets = (input.permissions.violationTicketPermissions.canWorkOnTickets);
-
-  //     roleToReturn = new RoleConverter().toPersistence(await repo.save(roleDo));
-  //   });
-  //   return roleToReturn;
-  // }
-
-  // async roleDeleteAndReassign(input: RoleDeleteAndReassignInput): Promise<RoleData> {
-  //   console.log(`roleDeleteAndReassign`, this.context.verifiedUser);
-  //   if (this.context.verifiedUser.openIdConfigKey !== 'AccountPortal') {
-  //     throw new Error('Unauthorized:roleDeleteAndReassign');
-  //   }
-
-  //   let mongoNewRole = await this.context.applicationServices.role.dataApi.getRoleById(input.roleToReassignTo);
-  //   let newROleDo = new RoleConverter().toDomain(mongoNewRole, { domainVisa: ReadOnlyDomainVisa.GetInstance() });
-  //   let roleToReturn: RoleData;
-  //   await this.withTransaction(async (repo) => {
-  //     let roleDo = await repo.getById(input.roleToDelete);
-  //     roleDo.deleteAndReassignTo = (newROleDo);
-  //     roleToReturn = new RoleConverter().toPersistence(await repo.save(roleDo));
-  //   });
-  //   return roleToReturn;
-  // }
 }

--- a/data-access/src/app/application-services/users/staff-user/staff-user.domain.ts
+++ b/data-access/src/app/application-services/users/staff-user/staff-user.domain.ts
@@ -2,12 +2,12 @@ import { DomainDataSource } from "../../../data-sources/domain-data-source";
 import { StaffUser } from "../../../domain/contexts/users/staff-user/staff-user";
 import { StaffUserData } from "../../../external-dependencies/datastore";
 import { StaffUserDomainAdapter, StaffUserConverter, StaffUserRepository } from "../../../external-dependencies/domain";
-import { UserUpdateInput } from "../../../external-dependencies/graphql-api";
+import { StaffUserUpdateInput } from "../../../external-dependencies/graphql-api";
 import { AppContext } from "../../../init/app-context-builder";
 
 export interface StaffUserDomainApi {
   addUser() : Promise<StaffUserData>;
-  updateUser(user: UserUpdateInput) : Promise<StaffUserData>; 
+  updateUser(user: StaffUserUpdateInput) : Promise<StaffUserData>; 
 }
 type PropType = StaffUserDomainAdapter;
 type DomainType = StaffUser<PropType>;
@@ -17,7 +17,7 @@ export class StaffUserDomainApiImpl
   extends DomainDataSource<AppContext, StaffUserData, PropType, DomainType, RepoType>
   implements StaffUserDomainApi {
 
-  async updateUser(user: UserUpdateInput): Promise<StaffUserData> {
+  async updateUser(user: StaffUserUpdateInput): Promise<StaffUserData> {
     if (!this.context.verifiedUser || this.context.verifiedUser.openIdConfigKey !== 'AccountPortal') {
       throw new Error('Unauthorized');
     }
@@ -28,9 +28,9 @@ export class StaffUserDomainApiImpl
       if (!domainObject || domainObject.externalId !== this.context.verifiedUser.verifiedJWT.sub) {
         throw new Error('Unauthorized');
       }
-      if (user?.personalInformation?.identityDetails?.restOfName !== undefined) domainObject.FirstName=(user.personalInformation?.identityDetails?.restOfName);
-      if (user?.personalInformation?.identityDetails?.lastName !== undefined) domainObject.LastName=(user.personalInformation?.identityDetails?.lastName);
-      if (user?.personalInformation?.contactInformation?.email !== undefined) domainObject.Email=(user.personalInformation?.contactInformation?.email);
+      if (user?.firstName !== undefined) domainObject.FirstName=(user.firstName);
+      if (user?.lastName !== undefined) domainObject.LastName=(user.lastName);
+      if (user?.email !== undefined) domainObject.Email=(user.email);
       result = (new StaffUserConverter()).toPersistence(await repo.save(domainObject));
     });
     return result;

--- a/data-access/src/routes/http/graphql/schema/builder/generated.ts
+++ b/data-access/src/routes/http/graphql/schema/builder/generated.ts
@@ -647,6 +647,9 @@ export type Mutation = {
   serviceTicketSubmit: ServiceTicketMutationResult;
   serviceTicketUpdate: ServiceTicketMutationResult;
   serviceUpdate: ServiceMutationResult;
+  staffUserCreate: StaffUserMutationResult;
+  /** Allows the user to update their profile */
+  staffUserUpdate: StaffUserMutationResult;
   userCreate: UserMutationResult;
   /** Allows the user to update their profile */
   userUpdate: UserMutationResult;
@@ -847,6 +850,11 @@ export type MutationServiceTicketUpdateArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationServiceUpdateArgs = {
   input: ServiceUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffUserUpdateArgs = {
+  input: StaffUserUpdateInput;
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -1173,6 +1181,9 @@ export type Query = {
   serviceTicketsSearch?: Maybe<ServiceTicketsSearchResult>;
   serviceTicketsSearchAdmin?: Maybe<ServiceTicketsSearchResult>;
   servicesByCommunityId?: Maybe<Array<Maybe<Service>>>;
+  staffUser?: Maybe<StaffUser>;
+  staffUserCurrent?: Maybe<StaffUser>;
+  staffUsers?: Maybe<Array<Maybe<StaffUser>>>;
   user?: Maybe<User>;
   userCurrent?: Maybe<User>;
   users?: Maybe<Array<Maybe<User>>>;
@@ -1273,6 +1284,11 @@ export type QueryServiceTicketsSearchAdminArgs = {
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
 export type QueryServicesByCommunityIdArgs = {
   communityId: Scalars['ID'];
+};
+
+/**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
+export type QueryStaffUserArgs = {
+  id: Scalars['ObjectID'];
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1553,6 +1569,35 @@ export type ServiceUpdateInput = {
   id: Scalars['ObjectID'];
   isActive?: InputMaybe<Scalars['Boolean']>;
   serviceName?: InputMaybe<Scalars['String']>;
+};
+
+export type StaffUser = MongoBase & {
+  __typename?: 'StaffUser';
+  accessBlocked?: Maybe<Scalars['Boolean']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  displayName?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  externalId?: Maybe<Scalars['String']>;
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  lastName?: Maybe<Scalars['String']>;
+  schemaVersion?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type StaffUserMutationResult = MutationResult & {
+  __typename?: 'StaffUserMutationResult';
+  status: MutationStatus;
+  user?: Maybe<StaffUser>;
+};
+
+export type StaffUserUpdateInput = {
+  displayName?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  lastName?: InputMaybe<Scalars['String']>;
 };
 
 export type Ticket = ServiceTicket | ViolationTicket;
@@ -1886,6 +1931,7 @@ export type ResolversTypes = ResolversObject<{
     | ResolversTypes['Role']
     | ResolversTypes['Service']
     | ResolversTypes['ServiceTicket']
+    | ResolversTypes['StaffUser']
     | ResolversTypes['User'];
   MongoSubdocument:
     | ResolversTypes['AdditionalAmenities']
@@ -1903,6 +1949,7 @@ export type ResolversTypes = ResolversObject<{
     | ResolversTypes['ServiceMutationResult']
     | ResolversTypes['ServiceTicketMutationResult']
     | ResolversTypes['ServiceTicketPhotoAuthHeaderResult']
+    | ResolversTypes['StaffUserMutationResult']
     | ResolversTypes['UserMutationResult']
     | ResolversTypes['ViolationTicketMutationResult'];
   MutationStatus: ResolverTypeWrapper<MutationStatus>;
@@ -1987,6 +2034,9 @@ export type ResolversTypes = ResolversObject<{
   ServiceTicketsSearchOptions: ServiceTicketsSearchOptions;
   ServiceTicketsSearchResult: ResolverTypeWrapper<ServiceTicketsSearchResult>;
   ServiceUpdateInput: ServiceUpdateInput;
+  StaffUser: ResolverTypeWrapper<StaffUser>;
+  StaffUserMutationResult: ResolverTypeWrapper<StaffUserMutationResult>;
+  StaffUserUpdateInput: StaffUserUpdateInput;
   String: ResolverTypeWrapper<Scalars['String']>;
   Ticket: ResolverTypeWrapper<ResolversUnionTypes['Ticket']>;
   Time: ResolverTypeWrapper<Scalars['Time']>;
@@ -2124,6 +2174,7 @@ export type ResolversParentTypes = ResolversObject<{
     | ResolversParentTypes['Role']
     | ResolversParentTypes['Service']
     | ResolversParentTypes['ServiceTicket']
+    | ResolversParentTypes['StaffUser']
     | ResolversParentTypes['User'];
   MongoSubdocument:
     | ResolversParentTypes['AdditionalAmenities']
@@ -2141,6 +2192,7 @@ export type ResolversParentTypes = ResolversObject<{
     | ResolversParentTypes['ServiceMutationResult']
     | ResolversParentTypes['ServiceTicketMutationResult']
     | ResolversParentTypes['ServiceTicketPhotoAuthHeaderResult']
+    | ResolversParentTypes['StaffUserMutationResult']
     | ResolversParentTypes['UserMutationResult']
     | ResolversParentTypes['ViolationTicketMutationResult'];
   MutationStatus: MutationStatus;
@@ -2225,6 +2277,9 @@ export type ResolversParentTypes = ResolversObject<{
   ServiceTicketsSearchOptions: ServiceTicketsSearchOptions;
   ServiceTicketsSearchResult: ServiceTicketsSearchResult;
   ServiceUpdateInput: ServiceUpdateInput;
+  StaffUser: StaffUser;
+  StaffUserMutationResult: StaffUserMutationResult;
+  StaffUserUpdateInput: StaffUserUpdateInput;
   String: Scalars['String'];
   Ticket: ResolversUnionParentTypes['Ticket'];
   Time: Scalars['Time'];
@@ -2749,7 +2804,7 @@ export type MemberProfileResolvers<
 }>;
 
 export type MongoBaseResolvers<ContextType = GraphqlContext, ParentType extends ResolversParentTypes['MongoBase'] = ResolversParentTypes['MongoBase']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Community' | 'Member' | 'Property' | 'Role' | 'Service' | 'ServiceTicket' | 'User', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'Community' | 'Member' | 'Property' | 'Role' | 'Service' | 'ServiceTicket' | 'StaffUser' | 'User', ParentType, ContextType>;
   createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
   schemaVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -2850,6 +2905,8 @@ export type MutationResolvers<ContextType = GraphqlContext, ParentType extends R
   serviceTicketSubmit?: Resolver<ResolversTypes['ServiceTicketMutationResult'], ParentType, ContextType, RequireFields<MutationServiceTicketSubmitArgs, 'input'>>;
   serviceTicketUpdate?: Resolver<ResolversTypes['ServiceTicketMutationResult'], ParentType, ContextType, RequireFields<MutationServiceTicketUpdateArgs, 'input'>>;
   serviceUpdate?: Resolver<ResolversTypes['ServiceMutationResult'], ParentType, ContextType, RequireFields<MutationServiceUpdateArgs, 'input'>>;
+  staffUserCreate?: Resolver<ResolversTypes['StaffUserMutationResult'], ParentType, ContextType>;
+  staffUserUpdate?: Resolver<ResolversTypes['StaffUserMutationResult'], ParentType, ContextType, RequireFields<MutationStaffUserUpdateArgs, 'input'>>;
   userCreate?: Resolver<ResolversTypes['UserMutationResult'], ParentType, ContextType>;
   userUpdate?: Resolver<ResolversTypes['UserMutationResult'], ParentType, ContextType, RequireFields<MutationUserUpdateArgs, 'input'>>;
   violationTicketAddUpdateActivity?: Resolver<
@@ -2888,6 +2945,7 @@ export type MutationResultResolvers<
     | 'ServiceMutationResult'
     | 'ServiceTicketMutationResult'
     | 'ServiceTicketPhotoAuthHeaderResult'
+    | 'StaffUserMutationResult'
     | 'UserMutationResult'
     | 'ViolationTicketMutationResult',
     ParentType,
@@ -3201,6 +3259,9 @@ export type QueryResolvers<ContextType = GraphqlContext, ParentType extends Reso
     RequireFields<QueryServiceTicketsSearchAdminArgs, 'input'>
   >;
   servicesByCommunityId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Service']>>>, ParentType, ContextType, RequireFields<QueryServicesByCommunityIdArgs, 'communityId'>>;
+  staffUser?: Resolver<Maybe<ResolversTypes['StaffUser']>, ParentType, ContextType, RequireFields<QueryStaffUserArgs, 'id'>>;
+  staffUserCurrent?: Resolver<Maybe<ResolversTypes['StaffUser']>, ParentType, ContextType>;
+  staffUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['StaffUser']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
   userCurrent?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
@@ -3415,6 +3476,30 @@ export type ServiceTicketsSearchResultResolvers<
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   facets?: Resolver<Maybe<ResolversTypes['ServiceTicketsSearchFacets']>, ParentType, ContextType>;
   serviceTicketsResults?: Resolver<Maybe<Array<Maybe<ResolversTypes['ServiceTicketsResult']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffUserResolvers<ContextType = GraphqlContext, ParentType extends ResolversParentTypes['StaffUser'] = ResolversParentTypes['StaffUser']> = ResolversObject<{
+  accessBlocked?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  externalId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  firstName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
+  lastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  schemaVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tags?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffUserMutationResultResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['StaffUserMutationResult'] = ResolversParentTypes['StaffUserMutationResult'],
+> = ResolversObject<{
+  status?: Resolver<ResolversTypes['MutationStatus'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['StaffUser']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3683,6 +3768,8 @@ export type Resolvers<ContextType = GraphqlContext> = ResolversObject<{
   ServiceTicketsResult?: ServiceTicketsResultResolvers<ContextType>;
   ServiceTicketsSearchFacets?: ServiceTicketsSearchFacetsResolvers<ContextType>;
   ServiceTicketsSearchResult?: ServiceTicketsSearchResultResolvers<ContextType>;
+  StaffUser?: StaffUserResolvers<ContextType>;
+  StaffUserMutationResult?: StaffUserMutationResultResolvers<ContextType>;
   Ticket?: TicketResolvers<ContextType>;
   Time?: GraphQLScalarType;
   TimeZone?: GraphQLScalarType;

--- a/data-access/src/routes/http/graphql/schema/builder/generated.ts
+++ b/data-access/src/routes/http/graphql/schema/builder/generated.ts
@@ -647,6 +647,9 @@ export type Mutation = {
   serviceTicketSubmit: ServiceTicketMutationResult;
   serviceTicketUpdate: ServiceTicketMutationResult;
   serviceUpdate: ServiceMutationResult;
+  staffRoleAdd: StaffRoleMutationResult;
+  staffRoleDeleteAndReassign: StaffRoleMutationResult;
+  staffRoleUpdate: StaffRoleMutationResult;
   staffUserCreate: StaffUserMutationResult;
   /** Allows the user to update their profile */
   staffUserUpdate: StaffUserMutationResult;
@@ -850,6 +853,21 @@ export type MutationServiceTicketUpdateArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationServiceUpdateArgs = {
   input: ServiceUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleAddArgs = {
+  input: StaffRoleAddInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleDeleteAndReassignArgs = {
+  input: StaffRoleDeleteAndReassignInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleUpdateArgs = {
+  input: StaffRoleUpdateInput;
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -1181,6 +1199,8 @@ export type Query = {
   serviceTicketsSearch?: Maybe<ServiceTicketsSearchResult>;
   serviceTicketsSearchAdmin?: Maybe<ServiceTicketsSearchResult>;
   servicesByCommunityId?: Maybe<Array<Maybe<Service>>>;
+  staffRole?: Maybe<StaffRole>;
+  staffRoles?: Maybe<Array<Maybe<StaffRole>>>;
   staffUser?: Maybe<StaffUser>;
   staffUserCurrent?: Maybe<StaffUser>;
   staffUsers?: Maybe<Array<Maybe<StaffUser>>>;
@@ -1284,6 +1304,11 @@ export type QueryServiceTicketsSearchAdminArgs = {
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
 export type QueryServicesByCommunityIdArgs = {
   communityId: Scalars['ID'];
+};
+
+/**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
+export type QueryStaffRoleArgs = {
+  id: Scalars['ObjectID'];
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1569,6 +1594,65 @@ export type ServiceUpdateInput = {
   id: Scalars['ObjectID'];
   isActive?: InputMaybe<Scalars['Boolean']>;
   serviceName?: InputMaybe<Scalars['String']>;
+};
+
+export type StaffCommunityPermissions = {
+  __typename?: 'StaffCommunityPermissions';
+  canChangeCommunityOwner: Scalars['Boolean'];
+  canDeleteCommunities: Scalars['Boolean'];
+  canManageAllCommunities: Scalars['Boolean'];
+  canManageStaffRolesAndPermissions: Scalars['Boolean'];
+  canReIndexSearchCollections: Scalars['Boolean'];
+};
+
+export type StaffCommunityPermissionsInput = {
+  canChangeCommunityOwner: Scalars['Boolean'];
+  canDeleteCommunities: Scalars['Boolean'];
+  canManageAllCommunities: Scalars['Boolean'];
+  canManageStaffRolesAndPermissions: Scalars['Boolean'];
+  canReIndexSearchCollections: Scalars['Boolean'];
+};
+
+export type StaffPermissions = {
+  __typename?: 'StaffPermissions';
+  communityPermissions: StaffCommunityPermissions;
+};
+
+export type StaffPermissionsInput = {
+  communityPermissions: StaffCommunityPermissionsInput;
+};
+
+export type StaffRole = MongoBase & {
+  __typename?: 'StaffRole';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['ObjectID'];
+  isDefault: Scalars['Boolean'];
+  permissions: StaffPermissions;
+  roleName: Scalars['String'];
+  schemaVersion?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type StaffRoleAddInput = {
+  permissions: StaffPermissionsInput;
+  roleName: Scalars['String'];
+};
+
+export type StaffRoleDeleteAndReassignInput = {
+  roleToDelete: Scalars['ObjectID'];
+  roleToReassignTo: Scalars['ObjectID'];
+};
+
+export type StaffRoleMutationResult = MutationResult & {
+  __typename?: 'StaffRoleMutationResult';
+  role?: Maybe<StaffRole>;
+  status: MutationStatus;
+};
+
+export type StaffRoleUpdateInput = {
+  id: Scalars['ObjectID'];
+  permissions: StaffPermissionsInput;
+  roleName: Scalars['String'];
 };
 
 export type StaffUser = MongoBase & {
@@ -1931,6 +2015,7 @@ export type ResolversTypes = ResolversObject<{
     | ResolversTypes['Role']
     | ResolversTypes['Service']
     | ResolversTypes['ServiceTicket']
+    | ResolversTypes['StaffRole']
     | ResolversTypes['StaffUser']
     | ResolversTypes['User'];
   MongoSubdocument:
@@ -1949,6 +2034,7 @@ export type ResolversTypes = ResolversObject<{
     | ResolversTypes['ServiceMutationResult']
     | ResolversTypes['ServiceTicketMutationResult']
     | ResolversTypes['ServiceTicketPhotoAuthHeaderResult']
+    | ResolversTypes['StaffRoleMutationResult']
     | ResolversTypes['StaffUserMutationResult']
     | ResolversTypes['UserMutationResult']
     | ResolversTypes['ViolationTicketMutationResult'];
@@ -2034,6 +2120,15 @@ export type ResolversTypes = ResolversObject<{
   ServiceTicketsSearchOptions: ServiceTicketsSearchOptions;
   ServiceTicketsSearchResult: ResolverTypeWrapper<ServiceTicketsSearchResult>;
   ServiceUpdateInput: ServiceUpdateInput;
+  StaffCommunityPermissions: ResolverTypeWrapper<StaffCommunityPermissions>;
+  StaffCommunityPermissionsInput: StaffCommunityPermissionsInput;
+  StaffPermissions: ResolverTypeWrapper<StaffPermissions>;
+  StaffPermissionsInput: StaffPermissionsInput;
+  StaffRole: ResolverTypeWrapper<StaffRole>;
+  StaffRoleAddInput: StaffRoleAddInput;
+  StaffRoleDeleteAndReassignInput: StaffRoleDeleteAndReassignInput;
+  StaffRoleMutationResult: ResolverTypeWrapper<StaffRoleMutationResult>;
+  StaffRoleUpdateInput: StaffRoleUpdateInput;
   StaffUser: ResolverTypeWrapper<StaffUser>;
   StaffUserMutationResult: ResolverTypeWrapper<StaffUserMutationResult>;
   StaffUserUpdateInput: StaffUserUpdateInput;
@@ -2174,6 +2269,7 @@ export type ResolversParentTypes = ResolversObject<{
     | ResolversParentTypes['Role']
     | ResolversParentTypes['Service']
     | ResolversParentTypes['ServiceTicket']
+    | ResolversParentTypes['StaffRole']
     | ResolversParentTypes['StaffUser']
     | ResolversParentTypes['User'];
   MongoSubdocument:
@@ -2192,6 +2288,7 @@ export type ResolversParentTypes = ResolversObject<{
     | ResolversParentTypes['ServiceMutationResult']
     | ResolversParentTypes['ServiceTicketMutationResult']
     | ResolversParentTypes['ServiceTicketPhotoAuthHeaderResult']
+    | ResolversParentTypes['StaffRoleMutationResult']
     | ResolversParentTypes['StaffUserMutationResult']
     | ResolversParentTypes['UserMutationResult']
     | ResolversParentTypes['ViolationTicketMutationResult'];
@@ -2277,6 +2374,15 @@ export type ResolversParentTypes = ResolversObject<{
   ServiceTicketsSearchOptions: ServiceTicketsSearchOptions;
   ServiceTicketsSearchResult: ServiceTicketsSearchResult;
   ServiceUpdateInput: ServiceUpdateInput;
+  StaffCommunityPermissions: StaffCommunityPermissions;
+  StaffCommunityPermissionsInput: StaffCommunityPermissionsInput;
+  StaffPermissions: StaffPermissions;
+  StaffPermissionsInput: StaffPermissionsInput;
+  StaffRole: StaffRole;
+  StaffRoleAddInput: StaffRoleAddInput;
+  StaffRoleDeleteAndReassignInput: StaffRoleDeleteAndReassignInput;
+  StaffRoleMutationResult: StaffRoleMutationResult;
+  StaffRoleUpdateInput: StaffRoleUpdateInput;
   StaffUser: StaffUser;
   StaffUserMutationResult: StaffUserMutationResult;
   StaffUserUpdateInput: StaffUserUpdateInput;
@@ -2804,7 +2910,7 @@ export type MemberProfileResolvers<
 }>;
 
 export type MongoBaseResolvers<ContextType = GraphqlContext, ParentType extends ResolversParentTypes['MongoBase'] = ResolversParentTypes['MongoBase']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Community' | 'Member' | 'Property' | 'Role' | 'Service' | 'ServiceTicket' | 'StaffUser' | 'User', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'Community' | 'Member' | 'Property' | 'Role' | 'Service' | 'ServiceTicket' | 'StaffRole' | 'StaffUser' | 'User', ParentType, ContextType>;
   createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
   schemaVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -2905,6 +3011,9 @@ export type MutationResolvers<ContextType = GraphqlContext, ParentType extends R
   serviceTicketSubmit?: Resolver<ResolversTypes['ServiceTicketMutationResult'], ParentType, ContextType, RequireFields<MutationServiceTicketSubmitArgs, 'input'>>;
   serviceTicketUpdate?: Resolver<ResolversTypes['ServiceTicketMutationResult'], ParentType, ContextType, RequireFields<MutationServiceTicketUpdateArgs, 'input'>>;
   serviceUpdate?: Resolver<ResolversTypes['ServiceMutationResult'], ParentType, ContextType, RequireFields<MutationServiceUpdateArgs, 'input'>>;
+  staffRoleAdd?: Resolver<ResolversTypes['StaffRoleMutationResult'], ParentType, ContextType, RequireFields<MutationStaffRoleAddArgs, 'input'>>;
+  staffRoleDeleteAndReassign?: Resolver<ResolversTypes['StaffRoleMutationResult'], ParentType, ContextType, RequireFields<MutationStaffRoleDeleteAndReassignArgs, 'input'>>;
+  staffRoleUpdate?: Resolver<ResolversTypes['StaffRoleMutationResult'], ParentType, ContextType, RequireFields<MutationStaffRoleUpdateArgs, 'input'>>;
   staffUserCreate?: Resolver<ResolversTypes['StaffUserMutationResult'], ParentType, ContextType>;
   staffUserUpdate?: Resolver<ResolversTypes['StaffUserMutationResult'], ParentType, ContextType, RequireFields<MutationStaffUserUpdateArgs, 'input'>>;
   userCreate?: Resolver<ResolversTypes['UserMutationResult'], ParentType, ContextType>;
@@ -2945,6 +3054,7 @@ export type MutationResultResolvers<
     | 'ServiceMutationResult'
     | 'ServiceTicketMutationResult'
     | 'ServiceTicketPhotoAuthHeaderResult'
+    | 'StaffRoleMutationResult'
     | 'StaffUserMutationResult'
     | 'UserMutationResult'
     | 'ViolationTicketMutationResult',
@@ -3259,6 +3369,8 @@ export type QueryResolvers<ContextType = GraphqlContext, ParentType extends Reso
     RequireFields<QueryServiceTicketsSearchAdminArgs, 'input'>
   >;
   servicesByCommunityId?: Resolver<Maybe<Array<Maybe<ResolversTypes['Service']>>>, ParentType, ContextType, RequireFields<QueryServicesByCommunityIdArgs, 'communityId'>>;
+  staffRole?: Resolver<Maybe<ResolversTypes['StaffRole']>, ParentType, ContextType, RequireFields<QueryStaffRoleArgs, 'id'>>;
+  staffRoles?: Resolver<Maybe<Array<Maybe<ResolversTypes['StaffRole']>>>, ParentType, ContextType>;
   staffUser?: Resolver<Maybe<ResolversTypes['StaffUser']>, ParentType, ContextType, RequireFields<QueryStaffUserArgs, 'id'>>;
   staffUserCurrent?: Resolver<Maybe<ResolversTypes['StaffUser']>, ParentType, ContextType>;
   staffUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['StaffUser']>>>, ParentType, ContextType>;
@@ -3476,6 +3588,46 @@ export type ServiceTicketsSearchResultResolvers<
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   facets?: Resolver<Maybe<ResolversTypes['ServiceTicketsSearchFacets']>, ParentType, ContextType>;
   serviceTicketsResults?: Resolver<Maybe<Array<Maybe<ResolversTypes['ServiceTicketsResult']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffCommunityPermissionsResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['StaffCommunityPermissions'] = ResolversParentTypes['StaffCommunityPermissions'],
+> = ResolversObject<{
+  canChangeCommunityOwner?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canDeleteCommunities?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canManageAllCommunities?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canManageStaffRolesAndPermissions?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canReIndexSearchCollections?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffPermissionsResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['StaffPermissions'] = ResolversParentTypes['StaffPermissions'],
+> = ResolversObject<{
+  communityPermissions?: Resolver<ResolversTypes['StaffCommunityPermissions'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffRoleResolvers<ContextType = GraphqlContext, ParentType extends ResolversParentTypes['StaffRole'] = ResolversParentTypes['StaffRole']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ObjectID'], ParentType, ContextType>;
+  isDefault?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  permissions?: Resolver<ResolversTypes['StaffPermissions'], ParentType, ContextType>;
+  roleName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  schemaVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type StaffRoleMutationResultResolvers<
+  ContextType = GraphqlContext,
+  ParentType extends ResolversParentTypes['StaffRoleMutationResult'] = ResolversParentTypes['StaffRoleMutationResult'],
+> = ResolversObject<{
+  role?: Resolver<Maybe<ResolversTypes['StaffRole']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['MutationStatus'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3768,6 +3920,10 @@ export type Resolvers<ContextType = GraphqlContext> = ResolversObject<{
   ServiceTicketsResult?: ServiceTicketsResultResolvers<ContextType>;
   ServiceTicketsSearchFacets?: ServiceTicketsSearchFacetsResolvers<ContextType>;
   ServiceTicketsSearchResult?: ServiceTicketsSearchResultResolvers<ContextType>;
+  StaffCommunityPermissions?: StaffCommunityPermissionsResolvers<ContextType>;
+  StaffPermissions?: StaffPermissionsResolvers<ContextType>;
+  StaffRole?: StaffRoleResolvers<ContextType>;
+  StaffRoleMutationResult?: StaffRoleMutationResultResolvers<ContextType>;
   StaffUser?: StaffUserResolvers<ContextType>;
   StaffUserMutationResult?: StaffUserMutationResultResolvers<ContextType>;
   Ticket?: TicketResolvers<ContextType>;

--- a/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
@@ -5343,6 +5343,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "StaffRole",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "StaffUser",
             "ofType": null
           },
@@ -6703,6 +6708,105 @@
             "deprecationReason": null
           },
           {
+            "name": "staffRoleAdd",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StaffRoleAddInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffRoleMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffRoleDeleteAndReassign",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StaffRoleDeleteAndReassignInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffRoleMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffRoleUpdate",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StaffRoleUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffRoleMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "staffUserCreate",
             "description": null,
             "args": [],
@@ -7096,6 +7200,11 @@
           {
             "kind": "OBJECT",
             "name": "ServiceTicketPhotoAuthHeaderResult",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StaffRoleMutationResult",
             "ofType": null
           },
           {
@@ -10321,6 +10430,51 @@
             "deprecationReason": null
           },
           {
+            "name": "staffRole",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ObjectID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StaffRole",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffRoles",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffRole",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "staffUser",
             "description": null,
             "args": [
@@ -13149,6 +13303,549 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffCommunityPermissions",
+        "description": null,
+        "fields": [
+          {
+            "name": "canChangeCommunityOwner",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canDeleteCommunities",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canManageAllCommunities",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canManageStaffRolesAndPermissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canReIndexSearchCollections",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffCommunityPermissionsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "canChangeCommunityOwner",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canDeleteCommunities",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canManageAllCommunities",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canManageStaffRolesAndPermissions",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canReIndexSearchCollections",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffPermissions",
+        "description": null,
+        "fields": [
+          {
+            "name": "communityPermissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffCommunityPermissions",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffPermissionsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "communityPermissions",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "StaffCommunityPermissionsInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffRole",
+        "description": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDefault",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffPermissions",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roleName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "schemaVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MongoBase",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffRoleAddInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "permissions",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "StaffPermissionsInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roleName",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffRoleDeleteAndReassignInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "roleToDelete",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roleToReassignTo",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffRoleMutationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "role",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StaffRole",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MutationStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MutationResult",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffRoleUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "permissions",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "StaffPermissionsInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roleName",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
@@ -5343,6 +5343,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "StaffUser",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "User",
             "ofType": null
           }
@@ -6698,6 +6703,55 @@
             "deprecationReason": null
           },
           {
+            "name": "staffUserCreate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffUserMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffUserUpdate",
+            "description": "Allows the user to update their profile",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StaffUserUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffUserMutationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userCreate",
             "description": null,
             "args": [],
@@ -7042,6 +7096,11 @@
           {
             "kind": "OBJECT",
             "name": "ServiceTicketPhotoAuthHeaderResult",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StaffUserMutationResult",
             "ofType": null
           },
           {
@@ -10262,6 +10321,63 @@
             "deprecationReason": null
           },
           {
+            "name": "staffUser",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ObjectID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StaffUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffUserCurrent",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StaffUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "staffUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "StaffUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "user",
             "description": null,
             "args": [
@@ -13028,6 +13144,283 @@
           },
           {
             "name": "serviceName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "accessBlocked",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "externalId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "schemaVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MongoBase",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StaffUserMutationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MutationStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StaffUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "MutationResult",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StaffUserUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "displayName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ObjectID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/data-access/src/routes/http/graphql/schema/types/staff-role.graphql
+++ b/data-access/src/routes/http/graphql/schema/types/staff-role.graphql
@@ -1,0 +1,67 @@
+# @format
+
+type StaffRole implements MongoBase {
+  roleName: String!
+  isDefault: Boolean!
+  permissions: StaffPermissions!
+
+  id: ObjectID!
+  schemaVersion: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+type StaffPermissions {
+  communityPermissions: StaffCommunityPermissions!
+}
+
+input StaffPermissionsInput {
+  communityPermissions: StaffCommunityPermissionsInput!
+}
+
+type StaffCommunityPermissions {
+  canManageStaffRolesAndPermissions: Boolean!
+  canManageAllCommunities: Boolean!
+  canDeleteCommunities: Boolean!
+  canChangeCommunityOwner: Boolean!
+  canReIndexSearchCollections: Boolean!
+}
+input StaffCommunityPermissionsInput {
+  canManageStaffRolesAndPermissions: Boolean!
+  canManageAllCommunities: Boolean!
+  canDeleteCommunities: Boolean!
+  canChangeCommunityOwner: Boolean!
+  canReIndexSearchCollections: Boolean!
+}
+
+extend type Query {
+  staffRoles: [StaffRole]
+  staffRole(id: ObjectID!): StaffRole
+}
+
+extend type Mutation {
+  staffRoleAdd(input: StaffRoleAddInput!): StaffRoleMutationResult!
+  staffRoleUpdate(input: StaffRoleUpdateInput!): StaffRoleMutationResult!
+  staffRoleDeleteAndReassign(input: StaffRoleDeleteAndReassignInput!): StaffRoleMutationResult!
+}
+
+type StaffRoleMutationResult implements MutationResult {
+  status: MutationStatus!
+  role: StaffRole
+}
+
+input StaffRoleAddInput {
+  roleName: String!
+  permissions: StaffPermissionsInput!
+}
+
+input StaffRoleUpdateInput {
+  id: ObjectID!
+  roleName: String!
+  permissions: StaffPermissionsInput!
+}
+
+input StaffRoleDeleteAndReassignInput {
+  roleToDelete: ObjectID!
+  roleToReassignTo: ObjectID!
+}

--- a/data-access/src/routes/http/graphql/schema/types/staff-role.resolvers.ts
+++ b/data-access/src/routes/http/graphql/schema/types/staff-role.resolvers.ts
@@ -1,0 +1,41 @@
+import { Resolvers, StaffRole, StaffRoleMutationResult } from '../builder/generated';
+import { StaffRole as StaffRoleDo } from '../../../../../infrastructure-services-impl/datastore/mongodb/models/roles/staff-role';
+
+const StaffRoleMutationResolver = async (getRole: Promise<StaffRoleDo>): Promise<StaffRoleMutationResult> => {
+  try {
+    return {
+      status: { success: true },
+      role: await getRole,
+    } as StaffRoleMutationResult;
+  } catch (error) {
+    console.error('StaffRole > Mutation  : ', error);
+    return {
+      status: { success: false, errorMessage: error.message },
+      role: null,
+    } as StaffRoleMutationResult;
+  }
+};
+
+const staffRole: Resolvers = {
+  Query: {
+    staffRole: async (_, { id }, { applicationServices }) => {
+      return (await applicationServices.roles.staffRole.dataApi.getRoleById(id)) as StaffRole;
+    },
+    staffRoles: async (_, _args, { applicationServices }) => {
+      return (await applicationServices.roles.staffRole.dataApi.getRoles()) as StaffRole[];
+    },
+  },
+  Mutation: {
+    staffRoleAdd(_parent, { input }, { applicationServices }) {
+      return StaffRoleMutationResolver(applicationServices.roles.staffRole.domainApi.roleAdd(input));
+    },
+    staffRoleUpdate(_parent, { input }, { applicationServices }) {
+      return StaffRoleMutationResolver(applicationServices.roles.staffRole.domainApi.roleUpdate(input));
+    },
+    staffRoleDeleteAndReassign(_parent, { input }, { applicationServices }) {
+      return StaffRoleMutationResolver(applicationServices.roles.staffRole.domainApi.roleDeleteAndReassign(input));
+    },
+  },
+};
+
+export default staffRole;

--- a/data-access/src/routes/http/graphql/schema/types/staff-user.graphql
+++ b/data-access/src/routes/http/graphql/schema/types/staff-user.graphql
@@ -1,0 +1,42 @@
+type StaffUser implements MongoBase {
+  externalId: String
+  displayName: String
+  firstName: String
+  lastName: String
+  email: String
+  accessBlocked: Boolean
+  tags: [String]
+
+  id: ObjectID!
+  schemaVersion: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+extend type Query {
+  staffUser(id: ObjectID!): StaffUser
+  staffUsers: [StaffUser]
+  staffUserCurrent: StaffUser
+}
+
+extend type Mutation {
+  staffUserCreate: StaffUserMutationResult!
+  """
+  Allows the user to update their profile
+  """
+  staffUserUpdate(input: StaffUserUpdateInput!): StaffUserMutationResult!
+}
+
+
+type StaffUserMutationResult implements MutationResult {
+  status: MutationStatus!
+  user: StaffUser
+}
+
+input StaffUserUpdateInput {
+  id: ObjectID!
+  displayName: String
+  firstName: String
+  lastName: String
+  email: String
+}

--- a/data-access/src/routes/http/graphql/schema/types/staff-user.resolvers.ts
+++ b/data-access/src/routes/http/graphql/schema/types/staff-user.resolvers.ts
@@ -1,0 +1,57 @@
+import { Resolvers, StaffUser } from '../builder/generated';
+import { cacheControlFromInfo } from '@apollo/cache-control-types';
+
+const staffUser: Resolvers = {
+  Query: {
+    staffUser: async (parent, args, context, info) => {
+      if (context.verifiedUser) {
+        console.log(`user found in context with JWT: ${JSON.stringify(context.verifiedUser.verifiedJWT)}`);
+      }
+      console.log(`Resolver>Query>staffUser ${args.id}`);
+      return (await context.applicationServices.users.staffUser.dataApi.getUserById(args.id)) as StaffUser;
+    },
+    staffUsers: async (parent, args, context, info) => {
+      cacheControlFromInfo(info).setCacheHint({ maxAge: 60, scope: 'PUBLIC' }); //this works, but doesn't work when setting it with a directive
+      console.log(`Resolver>Query>staffUsers`);
+      console.log(`Context VerifiedUser value: ${JSON.stringify(context.verifiedUser)}`);
+      return (await context.applicationServices.users.staffUser.dataApi.getUsers()) as StaffUser[];
+    },
+    staffUserCurrent: async (parent, args, context, info) => {
+      console.log(`Resolver>Query>staffUserCurrent`);
+      return (await context.applicationServices.users.staffUser.domainApi.addUser()) as StaffUser;
+    },
+  },
+  Mutation: {
+    staffUserCreate: async (parent, args, context, info) => {
+      return null;
+      //return (await context.applicationServices.user.domainApi.addUser()) as User;
+    },
+    staffUserUpdate: async (parent, args, context, info) => {
+      return null;
+      // return (await context.applicationServices.user.domainApi.updateUser(args.input)) as User;
+    },
+    /*
+    createAuthHeaderForProfilePhoto: async (parent, args, context, info) => {
+      const maxSizeMb = 10;
+      const maxSizeBytes = maxSizeMb * 1024 * 1024;
+      const permittedContentTypes = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+      ];
+      if (!permittedContentTypes.includes(args.input.contentType)) {
+        return {success:false, errorMessage:'Content type not permitted.'} as CreateAuthHeaderForProfilePhotoOutput;
+      }
+      if (args.input.contentLength > maxSizeBytes) {
+        return {success:false, errorMessage:'Content length exceeds permitted limit.'} as CreateAuthHeaderForProfilePhotoOutput;
+      }
+      var blobName = nanoid();
+      var requestDate = new Date().toUTCString();
+      var authHeader = new BlobStorage().generateSharedKey(blobName, args.input.contentLength, requestDate ,args.input.contentType);
+      return {success:true, authHeader:authHeader, requestDate:requestDate, blobName:blobName} as CreateAuthHeaderForProfilePhotoOutput;
+    }
+    */
+  },
+};
+
+export default staffUser;

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -645,6 +645,9 @@ export type Mutation = {
   serviceTicketSubmit: ServiceTicketMutationResult;
   serviceTicketUpdate: ServiceTicketMutationResult;
   serviceUpdate: ServiceMutationResult;
+  staffUserCreate: StaffUserMutationResult;
+  /** Allows the user to update their profile */
+  staffUserUpdate: StaffUserMutationResult;
   userCreate: UserMutationResult;
   /** Allows the user to update their profile */
   userUpdate: UserMutationResult;
@@ -845,6 +848,11 @@ export type MutationServiceTicketUpdateArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationServiceUpdateArgs = {
   input: ServiceUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffUserUpdateArgs = {
+  input: StaffUserUpdateInput;
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -1171,6 +1179,9 @@ export type Query = {
   serviceTicketsSearch?: Maybe<ServiceTicketsSearchResult>;
   serviceTicketsSearchAdmin?: Maybe<ServiceTicketsSearchResult>;
   servicesByCommunityId?: Maybe<Array<Maybe<Service>>>;
+  staffUser?: Maybe<StaffUser>;
+  staffUserCurrent?: Maybe<StaffUser>;
+  staffUsers?: Maybe<Array<Maybe<StaffUser>>>;
   user?: Maybe<User>;
   userCurrent?: Maybe<User>;
   users?: Maybe<Array<Maybe<User>>>;
@@ -1271,6 +1282,11 @@ export type QueryServiceTicketsSearchAdminArgs = {
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
 export type QueryServicesByCommunityIdArgs = {
   communityId: Scalars['ID'];
+};
+
+/**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
+export type QueryStaffUserArgs = {
+  id: Scalars['ObjectID'];
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1551,6 +1567,35 @@ export type ServiceUpdateInput = {
   id: Scalars['ObjectID'];
   isActive?: InputMaybe<Scalars['Boolean']>;
   serviceName?: InputMaybe<Scalars['String']>;
+};
+
+export type StaffUser = MongoBase & {
+  __typename?: 'StaffUser';
+  accessBlocked?: Maybe<Scalars['Boolean']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  displayName?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+  externalId?: Maybe<Scalars['String']>;
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  lastName?: Maybe<Scalars['String']>;
+  schemaVersion?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type StaffUserMutationResult = MutationResult & {
+  __typename?: 'StaffUserMutationResult';
+  status: MutationStatus;
+  user?: Maybe<StaffUser>;
+};
+
+export type StaffUserUpdateInput = {
+  displayName?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
+  firstName?: InputMaybe<Scalars['String']>;
+  id: Scalars['ObjectID'];
+  lastName?: InputMaybe<Scalars['String']>;
 };
 
 export type Ticket = ServiceTicket | ViolationTicket;

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -645,6 +645,9 @@ export type Mutation = {
   serviceTicketSubmit: ServiceTicketMutationResult;
   serviceTicketUpdate: ServiceTicketMutationResult;
   serviceUpdate: ServiceMutationResult;
+  staffRoleAdd: StaffRoleMutationResult;
+  staffRoleDeleteAndReassign: StaffRoleMutationResult;
+  staffRoleUpdate: StaffRoleMutationResult;
   staffUserCreate: StaffUserMutationResult;
   /** Allows the user to update their profile */
   staffUserUpdate: StaffUserMutationResult;
@@ -848,6 +851,21 @@ export type MutationServiceTicketUpdateArgs = {
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
 export type MutationServiceUpdateArgs = {
   input: ServiceUpdateInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleAddArgs = {
+  input: StaffRoleAddInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleDeleteAndReassignArgs = {
+  input: StaffRoleDeleteAndReassignInput;
+};
+
+/**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
+export type MutationStaffRoleUpdateArgs = {
+  input: StaffRoleUpdateInput;
 };
 
 /**  Base Mutation Type definition - all mutations will be defined in separate files extending this type  */
@@ -1179,6 +1197,8 @@ export type Query = {
   serviceTicketsSearch?: Maybe<ServiceTicketsSearchResult>;
   serviceTicketsSearchAdmin?: Maybe<ServiceTicketsSearchResult>;
   servicesByCommunityId?: Maybe<Array<Maybe<Service>>>;
+  staffRole?: Maybe<StaffRole>;
+  staffRoles?: Maybe<Array<Maybe<StaffRole>>>;
   staffUser?: Maybe<StaffUser>;
   staffUserCurrent?: Maybe<StaffUser>;
   staffUsers?: Maybe<Array<Maybe<StaffUser>>>;
@@ -1282,6 +1302,11 @@ export type QueryServiceTicketsSearchAdminArgs = {
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
 export type QueryServicesByCommunityIdArgs = {
   communityId: Scalars['ID'];
+};
+
+/**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
+export type QueryStaffRoleArgs = {
+  id: Scalars['ObjectID'];
 };
 
 /**  Base Query Type definition - , all mutations will be defined in separate files extending this type  */
@@ -1567,6 +1592,65 @@ export type ServiceUpdateInput = {
   id: Scalars['ObjectID'];
   isActive?: InputMaybe<Scalars['Boolean']>;
   serviceName?: InputMaybe<Scalars['String']>;
+};
+
+export type StaffCommunityPermissions = {
+  __typename?: 'StaffCommunityPermissions';
+  canChangeCommunityOwner: Scalars['Boolean'];
+  canDeleteCommunities: Scalars['Boolean'];
+  canManageAllCommunities: Scalars['Boolean'];
+  canManageStaffRolesAndPermissions: Scalars['Boolean'];
+  canReIndexSearchCollections: Scalars['Boolean'];
+};
+
+export type StaffCommunityPermissionsInput = {
+  canChangeCommunityOwner: Scalars['Boolean'];
+  canDeleteCommunities: Scalars['Boolean'];
+  canManageAllCommunities: Scalars['Boolean'];
+  canManageStaffRolesAndPermissions: Scalars['Boolean'];
+  canReIndexSearchCollections: Scalars['Boolean'];
+};
+
+export type StaffPermissions = {
+  __typename?: 'StaffPermissions';
+  communityPermissions: StaffCommunityPermissions;
+};
+
+export type StaffPermissionsInput = {
+  communityPermissions: StaffCommunityPermissionsInput;
+};
+
+export type StaffRole = MongoBase & {
+  __typename?: 'StaffRole';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['ObjectID'];
+  isDefault: Scalars['Boolean'];
+  permissions: StaffPermissions;
+  roleName: Scalars['String'];
+  schemaVersion?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type StaffRoleAddInput = {
+  permissions: StaffPermissionsInput;
+  roleName: Scalars['String'];
+};
+
+export type StaffRoleDeleteAndReassignInput = {
+  roleToDelete: Scalars['ObjectID'];
+  roleToReassignTo: Scalars['ObjectID'];
+};
+
+export type StaffRoleMutationResult = MutationResult & {
+  __typename?: 'StaffRoleMutationResult';
+  role?: Maybe<StaffRole>;
+  status: MutationStatus;
+};
+
+export type StaffRoleUpdateInput = {
+  id: Scalars['ObjectID'];
+  permissions: StaffPermissionsInput;
+  roleName: Scalars['String'];
 };
 
 export type StaffUser = MongoBase & {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces new GraphQL types, queries, and mutations for managing staff roles and users. It includes the addition of StaffRole, StaffUser, and related permissions types, as well as new domain APIs for handling staff role and user operations. The existing role and user domain APIs have been refactored to use the new input types, and the GraphQL schema and resolvers have been updated accordingly.

- **New Features**:
    - Introduced new GraphQL types and mutations for managing staff roles and users, including StaffRole, StaffUser, StaffPermissions, and related input types.
    - Added new GraphQL queries and mutations for staff roles and users, such as staffRoleAdd, staffRoleUpdate, staffRoleDeleteAndReassign, staffUserCreate, and staffUserUpdate.
    - Implemented new domain APIs for staff roles and users, including methods for adding, updating, and deleting roles, as well as updating user profiles.
- **Enhancements**:
    - Refactored existing role and user domain APIs to use new input types specific to staff roles and users.
    - Updated GraphQL schema and resolvers to support the new staff role and user management features.

<!-- Generated by sourcery-ai[bot]: end summary -->