### PR TITLE
Add missing phone number map to Cybersource billing information

### DIFF
--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.test.ts
@@ -103,6 +103,7 @@ test.skip('cybersource: get customer payment instrument', async () => {
   expect(response.card.expirationYear).toEqual('2024');
   expect(response.card.type).toEqual('001');
   expect(response._embedded.instrumentIdentifier.card.number).toEqual('411111XXXXXX1111');
+  expect(response.default).toBe(true);
 });
 
 test.skip('cybersource: get customer payment instruments', async () => {
@@ -111,6 +112,7 @@ test.skip('cybersource: get customer payment instruments', async () => {
   expect(response).toBeDefined();
   expect(response.total).toBeGreaterThan(0);
   expect(response._embedded.paymentInstruments.length).toBeGreaterThan(0);
+  expect(response._embedded.paymentInstruments[0].billTo.phoneNumber).toBeDefined();
 });
 
 test.skip('cybersource: delete customer payment instrument', async () => {

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -146,6 +146,7 @@ export class Cybersource implements CybersourceBase {
     orderInformationBillTo.postalCode = customerProfile.billingPostalCode;
     orderInformationBillTo.country = customerProfile.billingCountry;
     orderInformationBillTo.email = customerProfile.billingEmail;
+    orderInformationBillTo.phoneNumber = customerProfile.billingPhone;
 
     let orderInformation = new cybersource.Ptsv2paymentsOrderInformation();
     orderInformation.amountDetails = orderInformationAmountDetails;

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -146,7 +146,7 @@ export class Cybersource implements CybersourceBase {
     orderInformationBillTo.postalCode = customerProfile.billingPostalCode;
     orderInformationBillTo.country = customerProfile.billingCountry;
     orderInformationBillTo.email = customerProfile.billingEmail;
-    orderInformationBillTo.phoneNumber = customerProfile.billingPhone;
+    orderInformationBillTo.phoneNumber = customerProfile.billingPhone || '';
 
     let orderInformation = new cybersource.Ptsv2paymentsOrderInformation();
     orderInformation.amountDetails = orderInformationAmountDetails;

--- a/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
+++ b/data-access/seedwork/services-seedwork-payment-cybersource/index.ts
@@ -146,7 +146,7 @@ export class Cybersource implements CybersourceBase {
     orderInformationBillTo.postalCode = customerProfile.billingPostalCode;
     orderInformationBillTo.country = customerProfile.billingCountry;
     orderInformationBillTo.email = customerProfile.billingEmail;
-    orderInformationBillTo.phoneNumber = customerProfile.billingPhone || '';
+    orderInformationBillTo.phoneNumber = customerProfile.billingPhone ?? '';
 
     let orderInformation = new cybersource.Ptsv2paymentsOrderInformation();
     orderInformation.amountDetails = orderInformationAmountDetails;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Map phone number to Cybersource billing information and add corresponding test to ensure phone number is included in the billing details.

Tests:
- Add test to verify the presence of phone number in billing information for Cybersource payment instruments.

<!-- Generated by sourcery-ai[bot]: end summary -->