### PR TITLE
Renamed billTo field types to match the payment-instrument input field names

### DIFF
--- a/data-access/src/routes/http/graphql/schema/builder/generated.ts
+++ b/data-access/src/routes/http/graphql/schema/builder/generated.ts
@@ -927,16 +927,16 @@ export type MutationStatus = {
 
 export type PaymentBillingInfo = {
   __typename?: 'PaymentBillingInfo';
-  address1: Scalars['String'];
-  address2?: Maybe<Scalars['String']>;
-  administrativeArea: Scalars['String'];
-  country: Scalars['String'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  locality: Scalars['String'];
-  phoneNumber: Scalars['String'];
-  postalCode: Scalars['String'];
+  billingAddressLine1?: Maybe<Scalars['String']>;
+  billingAddressLine2?: Maybe<Scalars['String']>;
+  billingCity?: Maybe<Scalars['String']>;
+  billingCountry?: Maybe<Scalars['String']>;
+  billingEmail?: Maybe<Scalars['String']>;
+  billingFirstName?: Maybe<Scalars['String']>;
+  billingLastName?: Maybe<Scalars['String']>;
+  billingPhone?: Maybe<Scalars['String']>;
+  billingPostalCode?: Maybe<Scalars['String']>;
+  billingState?: Maybe<Scalars['String']>;
 };
 
 export type PaymentInstrument = {
@@ -3109,16 +3109,16 @@ export type PaymentBillingInfoResolvers<
   ContextType = GraphqlContext,
   ParentType extends ResolversParentTypes['PaymentBillingInfo'] = ResolversParentTypes['PaymentBillingInfo'],
 > = ResolversObject<{
-  address1?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  address2?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  administrativeArea?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  country?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  firstName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  lastName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  locality?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  phoneNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  postalCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  billingAddressLine1?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingAddressLine2?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingCity?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingCountry?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingFirstName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingLastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingPhone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingPostalCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  billingState?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
+++ b/data-access/src/routes/http/graphql/schema/builder/graphql.schema.json
@@ -7349,23 +7349,7 @@
         "description": null,
         "fields": [
           {
-            "name": "address1",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "address2",
+            "name": "billingAddressLine1",
             "description": null,
             "args": [],
             "type": {
@@ -7377,129 +7361,109 @@
             "deprecationReason": null
           },
           {
-            "name": "administrativeArea",
+            "name": "billingAddressLine2",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "country",
+            "name": "billingCity",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "email",
+            "name": "billingCountry",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "firstName",
+            "name": "billingEmail",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "lastName",
+            "name": "billingFirstName",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "locality",
+            "name": "billingLastName",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "phoneNumber",
+            "name": "billingPhone",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "postalCode",
+            "name": "billingPostalCode",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "billingState",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/data-access/src/routes/http/graphql/schema/types/member.graphql
+++ b/data-access/src/routes/http/graphql/schema/types/member.graphql
@@ -168,16 +168,16 @@ type PaymentInstrument {
 }
 
 type PaymentBillingInfo{
-  firstName: String!
-  lastName: String!
-  address1: String!
-  address2: String
-  locality: String! # The city of billing address
-  administrativeArea: String! # The region or state of the billing address
-  postalCode: String! # The postal code of the billing address
-  country: String! # The country of the billing address
-  email: String!
-  phoneNumber: String!
+  billingFirstName: String
+  billingLastName: String
+  billingAddressLine1: String
+  billingAddressLine2: String
+  billingCity: String # The city of billing address
+  billingState: String # The region or state of the billing address
+  billingPostalCode: String # The postal code of the billing address
+  billingCountry: String # The country of the billing address
+  billingEmail: String
+  billingPhone: String
 }
 
 type PaymentInstrumentResult {

--- a/ui-community/src/generated.tsx
+++ b/ui-community/src/generated.tsx
@@ -925,16 +925,16 @@ export type MutationStatus = {
 
 export type PaymentBillingInfo = {
   __typename?: 'PaymentBillingInfo';
-  address1: Scalars['String'];
-  address2?: Maybe<Scalars['String']>;
-  administrativeArea: Scalars['String'];
-  country: Scalars['String'];
-  email: Scalars['String'];
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  locality: Scalars['String'];
-  phoneNumber: Scalars['String'];
-  postalCode: Scalars['String'];
+  billingAddressLine1?: Maybe<Scalars['String']>;
+  billingAddressLine2?: Maybe<Scalars['String']>;
+  billingCity?: Maybe<Scalars['String']>;
+  billingCountry?: Maybe<Scalars['String']>;
+  billingEmail?: Maybe<Scalars['String']>;
+  billingFirstName?: Maybe<Scalars['String']>;
+  billingLastName?: Maybe<Scalars['String']>;
+  billingPhone?: Maybe<Scalars['String']>;
+  billingPostalCode?: Maybe<Scalars['String']>;
+  billingState?: Maybe<Scalars['String']>;
 };
 
 export type PaymentInstrument = {


### PR DESCRIPTION
Renamed billTo field types to match the payment-instrument input field names

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Rename billing-related fields in the GraphQL schema and related TypeScript types to match the payment-instrument input field names, ensuring consistency across the codebase.

Enhancements:
- Renamed billing-related fields in the GraphQL schema to align with payment-instrument input field names for consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->