### PR TITLE
Add logout button in staff section

### DIFF
--- a/ui-community/src/components/layouts/staff/section-layout.tsx
+++ b/ui-community/src/components/layouts/staff/section-layout.tsx
@@ -1,9 +1,13 @@
-import {Avatar, Button, Layout, Space } from "antd";
+import { Button, Layout } from "antd";
 import { Outlet } from 'react-router-dom';
 import { useAuth } from 'react-oidc-context';
 import { GetUserRoles, UserRoles } from '../../../constants';
 
-export const SectionLayout: React.FC<any> = () => {
+export interface SectionLayoutProps {
+  
+}
+
+export const SectionLayout: React.FC<SectionLayoutProps> = () => {
   const auth = useAuth();
   const userRoles = GetUserRoles();
 

--- a/ui-community/src/components/layouts/staff/section-layout.tsx
+++ b/ui-community/src/components/layouts/staff/section-layout.tsx
@@ -1,10 +1,27 @@
-import { Layout } from "antd";
+import {Avatar, Button, Layout, Space } from "antd";
 import { Outlet } from 'react-router-dom';
+import { useAuth } from 'react-oidc-context';
+import { GetUserRoles, UserRoles } from '../../../constants';
 
 export const SectionLayout: React.FC<any> = () => {
+  const auth = useAuth();
+  const userRoles = GetUserRoles();
+
+  const handleLogout = async () => {
+    await auth.removeUser();
+    await auth.signoutRedirect({ post_logout_redirect_uri: window.location.origin });
+  };
+  
   return (
-    <Layout className="site-layout" style={{ minHeight: '100vh' }}>
-      <Outlet />
+    <Layout className='site-layout' style={{ minHeight: '100vh' }}>
+      <div className='text-right ml-3'>
+        <Button style={{ margin: '5px 5px' }} onClick={() => handleLogout()}>Log Out</Button>
+      </div>
+      {userRoles.includes(UserRoles.Staff) ? (
+        <Outlet />
+      ) : (
+        <div>You are not a Staff user</div>
+      )}
     </Layout>
   )
 }


### PR DESCRIPTION
This pull request adds a logout button in the staff section of the application. The button allows staff users to log out of their accounts.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a logout button in the staff section, enabling staff users to log out of their accounts. The button is conditionally rendered based on user roles.

New Features:
- Add a logout button in the staff section to allow staff users to log out of their accounts.

<!-- Generated by sourcery-ai[bot]: end summary -->