### PR TITLE
service ticket permissions bugfix

### DIFF
--- a/data-access/src/app/domain/contexts/cases/service-ticket/v1/service-ticket-v1-revision-request.ts
+++ b/data-access/src/app/domain/contexts/cases/service-ticket/v1/service-ticket-v1-revision-request.ts
@@ -72,7 +72,13 @@ export class ServiceTicketV1RevisionRequest extends ValueObject<ServiceTicketV1R
   }
 
   set RevisionSubmittedAt(revisionSubmittedAt: Date) {
-    this.validateVisa();
+    if (!this.visa.determineIf((permissions) => 
+      permissions.isEditingOwnTicket || 
+      (permissions.canManageTickets && permissions.isEditingAssignedTicket) ||
+      permissions.isSystemAccount
+    )) {
+      throw new Error('Unauthorized');
+    }
     this.props.revisionSubmittedAt = revisionSubmittedAt;
   }
 

--- a/data-access/src/app/domain/contexts/cases/service-ticket/v1/service-ticket.visa.ts
+++ b/data-access/src/app/domain/contexts/cases/service-ticket/v1/service-ticket.visa.ts
@@ -31,7 +31,7 @@ export class ServiceTicketV1VisaImpl<root extends ServiceTicketV1EntityReference
       isEditingOwnTicket: {
         value: (this.member.id === this.root.requestor.id)
       },
-      isEditingAssignedTickets: {
+      isEditingAssignedTicket: {
         value: (
           this.root.assignedTo?.id &&
           this.member.id === this.root.assignedTo.id)

--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/violation-ticket-v1-revision-request.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/violation-ticket-v1-revision-request.ts
@@ -73,7 +73,11 @@ export class ViolationTicketV1RevisionRequest extends ValueObject<ViolationTicke
   }
 
   set RevisionSubmittedAt(revisionSubmittedAt: Date) {
-    if (!this.visa.determineIf((permissions) => permissions.isEditingOwnTicket || (permissions.canManageTickets && permissions.isEditingAssignedTicket))) {
+    if (!this.visa.determineIf((permissions) => 
+      permissions.isEditingOwnTicket || 
+      (permissions.canManageTickets && permissions.isEditingAssignedTicket) ||
+      permissions.isSystemAccount
+    )) {
       throw new Error('Unauthorized');
     }
     this.props.revisionSubmittedAt = revisionSubmittedAt;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix permission validation for submitting revisions on service and violation tickets to include system accounts and rename a permission check for consistency.

Bug Fixes:
- Fix permission validation logic for submitting revisions on service and violation tickets to include system accounts.

Enhancements:
- Rename permission check from 'isEditingAssignedTickets' to 'isEditingAssignedTicket' for consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->