### PR TITLE
generate schema definitions

### DIFF
--- a/data-access-generator/src/index.ts
+++ b/data-access-generator/src/index.ts
@@ -1,4 +1,4 @@
-import { ModelSchemaInputStructure, SchemaTypeEnum } from "./common";
+import { ModelSchemaInputStructure, RawInputFromModel, SchemaTypeEnum } from "./common";
 import { DataAccessPainKiller } from "./step-2-data-access-pain-killer";
 import { GenerateGraphQLSchema } from "./step-3-export-to-graphql";
 import { ExtractFullAggregateRootInputStructure } from "./step-1-raw-input-interface-model-to-tool-input-helpers";
@@ -6,29 +6,25 @@ import { rawInputApplicantUser } from "./raw-inputs/raw-input-applicant-user";
 import { rawInputEntity } from "./raw-inputs/raw-input-entity";
 import { rawInputIdentityCase } from "./raw-inputs/raw-input-identity-case";
 import { rawInputStaffUser } from "./raw-inputs/raw-input-staff-user";
+import { GenerateSchemaDefinitions } from "./step-4-generate-schema-definitions";
+import { rawInputCredentialVerificationCase } from "./raw-inputs/raw-input-credential-verification-case";
 
+const StartPainKilling = (rawInput: RawInputFromModel) => {
+  const entityInputStructure = ExtractFullAggregateRootInputStructure(rawInput);
+  DataAccessPainKiller(entityInputStructure);
+  GenerateGraphQLSchema(entityInputStructure);
+  GenerateSchemaDefinitions(entityInputStructure);
+};
 
+StartPainKilling(rawInputEntity);
 
+StartPainKilling(rawInputApplicantUser);
 
-const entityInputStructure = ExtractFullAggregateRootInputStructure(rawInputEntity);
-DataAccessPainKiller(entityInputStructure);
-GenerateGraphQLSchema(entityInputStructure);
+StartPainKilling(rawInputIdentityCase);
 
-const applicantUserInputStructure = ExtractFullAggregateRootInputStructure(rawInputApplicantUser);
-DataAccessPainKiller(applicantUserInputStructure);
-GenerateGraphQLSchema(applicantUserInputStructure);
+StartPainKilling(rawInputStaffUser);
 
-const idVerificationCaseInputStructure = ExtractFullAggregateRootInputStructure(rawInputIdentityCase);
-DataAccessPainKiller(idVerificationCaseInputStructure);
-GenerateGraphQLSchema(idVerificationCaseInputStructure);
-
-const staffUserInputStructure = ExtractFullAggregateRootInputStructure(rawInputStaffUser);
-DataAccessPainKiller(staffUserInputStructure);
-GenerateGraphQLSchema(staffUserInputStructure);
-
-
-
-
+StartPainKilling(rawInputCredentialVerificationCase);
 
 // (async () => {
 //   const module = await import("iso-639-2");

--- a/data-access-generator/src/raw-inputs/raw-input-applicant-user.ts
+++ b/data-access-generator/src/raw-inputs/raw-input-applicant-user.ts
@@ -3,7 +3,7 @@ import { RawInputFromModel } from "../common";
 export const rawInputApplicantUser: RawInputFromModel = {
   aggregateRootDefinition: `
 export interface ApplicantUser extends User {
-  termsAndConditions?: Types.DocumentArray<ApplicantUserTermsAndConditions>
+  termsAndConditions?: Types.DocumentArray<ApplicantUserTermsAndCondition>;
   personalInformation?: ApplicantUserPersonalInformation;
   accessBlocked?: boolean;
   tags?: string[];
@@ -11,9 +11,9 @@ export interface ApplicantUser extends User {
   displayName?: string;
   userType?: string; // Discriminator key
   discriminatorKey: string;
-  schemaVersion: string;
   externalId: string;
   isProfileSubmitted?: boolean;
+  payment?: ApplicantUserPayment;
 }`,
   complexSchemaTypeDefinitions: `export interface ApplicantUserSearch extends NestedPath {
   hash?: string;

--- a/data-access-generator/src/raw-inputs/raw-input-credential-verification-case.ts
+++ b/data-access-generator/src/raw-inputs/raw-input-credential-verification-case.ts
@@ -1,0 +1,276 @@
+import { RawInputFromModel } from "../common";
+
+export const rawInputCredentialVerificationCase: RawInputFromModel = {
+  version: "1",
+  aggregateRootDefinition: `
+export interface CredentialVerificationCase extends Case {
+  caseDetails?: CredentialVerificationCaseCaseDetails;
+  assets: CredentialVerificationCaseAssets;
+  revisionRequest: CredentialVerificationCaseRevisionRequest;
+  caseHistory: Types.DocumentArray<CredentialVerificationCaseCaseHistory>;
+  messages: Types.DocumentArray<CredentialVerificationCaseMessage>;
+  financeDetails: CredentialVerificationCaseFinanceDetails;
+  activityLog?: Types.DocumentArray<CredentialVerificationCaseActivityLog>;
+
+  applicant: PopulatedDoc<ApplicantUser.ApplicantUser>;
+  submittedAt?: Date;
+  purgeEligibleAt?: Date;
+  expirationEligibleAt?: Date;
+
+  caseType?: string;
+  discriminatorKey: string;
+  state: string;
+
+  caseName: string;
+  systemTags?: string[];
+  tags?: string[];
+  caseFlagged?: Types.DocumentArray<CredentialVerificationCaseCaseFlagged>;
+  search?: CredentialVerificationCaseSearch;
+}
+`, 
+  complexSchemaTypeDefinitions: `
+
+ export interface CredentialVerificationCaseOtherIssuingInstitution extends NestedPath {
+  institutionName?: string;
+  addressLine1?: string;
+  city?: string;
+  stateOrProvince?: string;
+  zipOrPostalCode?: string;
+  country?: string;
+}
+
+export interface CredentialVerificationCaseCredentialAssets extends NestedPath {
+  credential?: string; // assetReference, id form asset reference uploaded by applicant
+  credentialUploadedAt?: Date;
+  credentialVersion?: string;
+  translation?: string; // assetReference, id form asset reference uploaded by applicant
+  translationUploadedAt?: Date;
+  translationVersion?: string;
+}
+
+export interface CredentialVerificationCaseEntitySuppliedCredential extends NestedPath {
+  credential?: string; // assetReference, id form asset reference uploaded by applicant
+  credentialUploadedAt?: Date;
+  credentialVersion?: string;
+  translation?: string; // assetReference, id form asset reference uploaded by applicant
+  translationUploadedAt?: Date;
+  translationVersion?: string;
+}
+
+export interface CredentialVerificationCaseAudit extends NestedPath {
+  completedOn?: Date;
+  completedBy: PopulatedDoc<StaffUser.StaffUser>;
+  result?: string;
+}
+
+export interface CredentialVerificationCaseAffirmations extends NestedPath {
+  isNameAcceptable?: boolean;
+  isTranslationAcceptable?: boolean;
+  isCredentialAcceptable?: boolean;
+  isCredentialDetailsAcceptable?: boolean;
+  isDateOfBirthAcceptable?: boolean;
+  isEntityAcceptable?: boolean;
+  isCredentialSentForVerification?: boolean;
+  audit?: CredentialVerificationCaseAudit;
+}
+
+export interface CredentialVerificationCaseVerificationAffirmations extends NestedPath {
+  isReturnedFromCorrectEntity?: boolean;
+  isVerificationMethodAcceptable?: boolean;
+  isVerificationComplete?: boolean;
+  isVerificationInEnglishOrWithTranslation?: boolean;
+  isEntityDetailCorrect?: boolean;
+  isCredentialReturnedFromEntity?: boolean;
+  isVerificationStatusComplete?: boolean;
+  isVerificationComponentPacketCompiled?: boolean;
+  audit?: CredentialVerificationCaseAudit;
+}
+
+export interface CredentialVerificationCaseInstitutionContactDetails extends NestedPath {
+  institutionEmail?: string;
+  institutionPhone?: string;
+}
+
+export interface CredentialVerificationCaseAlternateVerifyingEntity extends NestedPath {
+  isVerifiedWithOther?: boolean;
+  otherDetails?: string;
+}
+
+export interface CredentialVerificationCaseVerificationStatus extends NestedPath {
+  verificationResponse?: string;
+}
+
+export interface CredentialVerificationCasePrivateCaseDetails extends NestedPath {
+  institutionContactDetails?: CredentialVerificationCaseInstitutionContactDetails;
+  alternateVerifyingEntity?: CredentialVerificationCaseAlternateVerifyingEntity;
+  verificationStatus?: CredentialVerificationCaseVerificationStatus;
+  entitySuppliedCredential?: CredentialVerificationCaseEntitySuppliedCredential;
+}
+
+export interface CredentialVerificationCaseApplicationReviewDecision extends NestedPath {
+  completedOn?: Date;
+  completedBy?: PopulatedDoc<StaffUser.StaffUser>;
+  result?: string;
+  rejectionReason?: string;
+}
+
+export interface CredentialVerificationCaseApplicationReview extends NestedPath {
+  caseWorkerAssigned?: PopulatedDoc<StaffUser.StaffUser>;
+  affirmations?: CredentialVerificationCaseAffirmations;
+  verificationAffirmations?: CredentialVerificationCaseVerificationAffirmations;
+  privateCaseDetails?: CredentialVerificationCasePrivateCaseDetails;
+  decision?: CredentialVerificationCaseApplicationReviewDecision;
+  createdAt?: Date;
+}
+
+export interface CredentialVerificationCaseAssetsPrivate extends NestedPath {
+  verificationForm?: string;
+  verificationFormHistory?: Types.DocumentArray<CredentialVerificationCaseAssetHistory>;
+  verificationPacket?: string;
+  verificationPacketHistory?: Types.DocumentArray<CredentialVerificationCaseAssetHistory>;
+  verificationPacketResponse?: string;
+  verificationPacketResponseHistory?: Types.DocumentArray<CredentialVerificationCaseAssetHistory>;
+  verificationComponentPacket?: string;
+  verificationComponentPacketHistory?: Types.DocumentArray<CredentialVerificationCaseAssetHistory>;
+}
+export interface CredentialVerificationCaseAssets extends NestedPath {
+  private?: CredentialVerificationCaseAssetsPrivate;
+  arbitrary?: string;
+}
+
+export interface CredentialVerificationCaseAssetHistory extends SubdocumentBase {
+  assetVersion?: string;
+  assetUploadedBy?: PopulatedDoc<StaffUser.StaffUser>;
+}
+
+export interface CredentialVerificationCaseRequestedChanges extends NestedPath {
+  requestUpdatedCredentialDetails?: boolean;
+  requestUploadCredential?: boolean;
+  requestUploadTranslation?: boolean;
+  requestUpdatedIssuingInstitution?: boolean;
+}
+
+export interface CredentialVerificationCaseRevisionRequest extends NestedPath {
+  requestedAt?: Date;
+  requestedBy?: PopulatedDoc<StaffUser.StaffUser>;
+  revisionSummary?: string;
+  requestedChanges?: CredentialVerificationCaseRequestedChanges;
+  revisionSubmittedAt?: Date;
+}
+
+export interface CredentialVerificationCaseCaseHistory extends SubdocumentBase {
+  caseDetails?: CredentialVerificationCaseApplicationReview;
+  revisionRequest?: CredentialVerificationCaseRevisionRequest;
+}
+
+export interface CredentialVerificationCaseMessage extends SubdocumentBase {
+  sentBy?: string; // enum external,internal
+  initiatedBy?: PopulatedDoc<StaffUser.StaffUser>;
+  message?: string;
+  embedding?: string;
+  isHiddenFromApplicant?: boolean;
+}
+
+export interface CredentialVerificationCaseRevenueRecognitionSubmission extends NestedPath {
+  debitGlAccount?: string;
+  creditGlAccount?: string;
+  amount?: number;
+  recognitionDate?: Date;
+  completedOn?: Date;
+}
+
+export interface CredentialVerificationCaseRevenueRecognitionRecognition extends NestedPath {
+  debitGlAccount?: string;
+  creditGlAccount?: string;
+  amount?: number;
+  recognitionDate?: Date;
+  completedOn?: Date;
+}
+
+export interface CredentialVerificationCaseRevenueRecognition extends NestedPath {
+  submission?: CredentialVerificationCaseRevenueRecognitionSubmission;
+  recognition?: CredentialVerificationCaseRevenueRecognitionRecognition;
+}
+
+export interface CredentialVerificationCaseFinanceDetails extends NestedPath {
+  serviceFee?: number;
+  revenueRecognition?: CredentialVerificationCaseRevenueRecognition;
+  transactions?: CredentialVerificationCaseFinanceDetailsTransactions;
+}
+
+export interface CredentialVerificationCaseTransactionReference extends NestedPath {
+  vendor?: string;
+  referenceId?: string;
+  completedOn?: Date;
+}
+
+export interface CredentialVerificationCaseFinanceDetailsTransactionSubmission extends NestedPath {
+  amount?: number;
+  transactionReference: CredentialVerificationCaseTransactionReference;
+}
+
+export interface CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactionsApproval extends NestedPath {
+  isApplicantApprovalRequired?: boolean;
+  isAppplantApproved?: boolean;
+  applicantRepondedAt?: Date;
+}
+
+export interface CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactionsFinanceReference extends NestedPath {
+  debitGlAccount?: string;
+  creditGlAccount?: string;
+  completedOn?: Date;
+}
+
+export interface CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactions extends SubdocumentBase {
+  amount?: number;
+  requestedOn?: Date;
+  requestedBy: PopulatedDoc<StaffUser.StaffUser>;
+  reason?: string;
+  approval?: CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactionsApproval;
+  transactionReference?: CredentialVerificationCaseTransactionReference;
+  financeReference?: CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactionsFinanceReference;
+}
+
+export interface CredentialVerificationCaseFinanceDetailsTransactions extends NestedPath {
+  submission?: CredentialVerificationCaseFinanceDetailsTransactionSubmission;
+  adhocTransactions?: Types.DocumentArray<CredentialVerificationCaseFinanceDetailsTransactionAdhocTransactions>;
+}
+
+export interface CredentialVerificationCaseActivityLog extends SubdocumentBase {
+  activity?: string;
+  activityBy?: PopulatedDoc<User.User>;
+  description?: string;
+  metaData?: string;
+  tags?: string[];
+}
+
+export interface CredentialVerificationCaseCaseFlagged extends SubdocumentBase {
+  flagType?: string;
+  reason?: string;
+}
+
+export interface CredentialVerificationCaseSearch extends NestedPath {
+  hash: string;
+  indexedAt: Date;
+  indexingFailedAt?: Date;
+}
+
+export interface CredentialVerificationCaseApplication extends NestedPath {
+  attestedAt?: Date;
+  credentialTitle?: string;
+  program?: string;
+  nameOnCredential?: string;
+  dateCredentialIssued?: Date;
+  credentialType?: string;
+  isCredentialInEnglish?: boolean;
+  issuingInstitution?: PopulatedDoc<Entity.Entity>;
+  otherIssuingInstitution?: CredentialVerificationCaseOtherIssuingInstitution;
+  credentialAssets?: CredentialVerificationCaseCredentialAssets;
+  sendDestination?: string;
+}
+
+export interface CredentialVerificationCaseCaseDetails extends NestedPath {
+  application?: CredentialVerificationCaseApplication;
+  applicationReview?: CredentialVerificationCaseApplicationReview;
+}`
+}

--- a/data-access-generator/src/step-1-raw-input-interface-model-to-tool-input-helpers.ts
+++ b/data-access-generator/src/step-1-raw-input-interface-model-to-tool-input-helpers.ts
@@ -27,7 +27,7 @@ const extractDocumentArrayType = (type: string) => {
 
 // hash: string; => ["hash", "string"]
 const extractFields = (input: string) => {
-  const fieldsRegex = /(\w+\?*): (.+);/g;
+  const fieldsRegex = /(\w+\?*): ([^;]+)(?=;|$)/g;
   const rawFields = input.matchAll(fieldsRegex);
   const fields: Field[] = [];
 

--- a/data-access-generator/src/step-2-data-access-pain-killer.ts
+++ b/data-access-generator/src/step-2-data-access-pain-killer.ts
@@ -12,7 +12,7 @@ import { GetDomainEntityDefinitions } from "./templates/entity/entity-helpers";
 import { GetDomainValueObjectDefinitions } from "./templates/value-object/value-object-helpers";
 
 export const DataAccessPainKiller = (inputStructure: ModelSchemaInputStructure) => {
-  console.log("Killing pain...");
+  console.log("Killing pain for ", inputStructure.name, "...");
   // Generate Domain Aggregate Root file
   GetDomainAggregateRootDefinition(inputStructure);
 
@@ -36,9 +36,8 @@ export const DataAccessPainKiller = (inputStructure: ModelSchemaInputStructure) 
 
   // Generate Domain Context DomainEntity files
   GetDomainEntityDefinitions(inputStructure);
-  console.log("You should be good to go now!");
-  console.log(chalk.yellow("Summary: "));
-  console.log(chalk.blue("Aggregate Root Name:"), inputStructure.name);
+  console.log(chalk.blue("You should be good to go now!"))
+  console.log(chalk.blue("Summary: "));
   console.log(chalk.blue("Number of NestedPaths:"), inputStructure.nestedPaths?.length);
   console.log(chalk.blue("Number of SubdocumentBases:"), inputStructure.subdocumentBases?.length);
 };

--- a/data-access-generator/src/step-3-export-to-graphql.ts
+++ b/data-access-generator/src/step-3-export-to-graphql.ts
@@ -2,9 +2,9 @@ import * as fs from "fs";
 import * as path from "path";
 import { InsertVersionMiddleOfType as InsertVersionMiddleOfComplexType, ModelSchemaInputStructure, SchemaTypeEnum, toKebabCase } from "./common";
 
-const RefineGraphqlTypeFromModelType = (modelType: string, schemaType: SchemaTypeEnum, isSimpleDate: boolean) => {
+const RefineGraphqlTypeFromModelType = (modelFieldType: string, schemaType: SchemaTypeEnum, isSimpleDate: boolean) => {
   if (schemaType === SchemaTypeEnum.Primitive) {
-    switch (modelType) {
+    switch (modelFieldType) {
       case "string":
         return "String";
       case "string[]":
@@ -21,15 +21,15 @@ const RefineGraphqlTypeFromModelType = (modelType: string, schemaType: SchemaTyp
       case "ObjectID":
         return "ObjectID";
       default:
-        return modelType;
+        return modelFieldType;
     }
   } else if (schemaType === SchemaTypeEnum.PopulatedDoc) {
-    return modelType;
+    return modelFieldType;
   } else if (schemaType === SchemaTypeEnum.DocumentArray) {
-    return `[${modelType}]`;
+    return `[${modelFieldType}]`;
   } else {
     // NestedPath
-    return modelType;
+    return modelFieldType;
   }
 };
 

--- a/data-access-generator/src/step-4-generate-schema-definitions.ts
+++ b/data-access-generator/src/step-4-generate-schema-definitions.ts
@@ -1,0 +1,78 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ModelSchemaInputStructure, SchemaTypeEnum, toKebabCase } from "./common";
+
+const RefineSchemaTypeFromModelType = (modelFieldType: string, schemaType: SchemaTypeEnum) => {
+  if (schemaType === SchemaTypeEnum.Primitive) {
+    switch (modelFieldType) {
+      case "string":
+        return "{ type: String, required: false}";
+      case "string[]":
+        return "{ type: [String], required: false}";
+      case "number":
+        return "{ type: Number, required: false}";
+      case "boolean":
+        return "{ type: Boolean, required: false}";
+      case "ObjectID":
+        return "ObjectID";
+      default:
+        return `{ type: ${modelFieldType}, required: false}`;
+    }
+  } else if (schemaType === SchemaTypeEnum.PopulatedDoc) {
+    return `{ type: Schema.Types.ObjectId, ref: ${modelFieldType}.${modelFieldType}Model.modelName, required: false}
+`;
+  } else if (schemaType === SchemaTypeEnum.DocumentArray) {
+    return `{ type: [${modelFieldType}Schema], required: false }
+`;
+  } else {
+    // NestedPath
+    return `{type: ${modelFieldType}Type,required: false, ...NestedPathOptions,}`;
+  }
+};
+
+export const GenerateSchemaDefinitions = (modelSchemaInput: ModelSchemaInputStructure) => {
+  let result = "";
+  const template = fs.readFileSync(path.join(__dirname, "./templates/schema-template.txt"), "utf8");
+
+  // generate base schema
+  result += template.replace(/ModelName/g, modelSchemaInput.name);
+
+  // generate fields
+  let baseFields = modelSchemaInput.fields.map((field) => {
+    return `${field.name}: ${RefineSchemaTypeFromModelType(field.type, field.schemaType!)}`;
+  });
+  result = result.replace(/\/\/FieldDefinitions/g, baseFields.join(",\n") + ",");
+
+  // generate nested path types
+  let nestedPathTypeDefinitions = "";
+  for (const nestedPath of modelSchemaInput.nestedPaths ?? []) {
+    let nestedPathFields = nestedPath.fields.map((field) => {
+      return `${field.name}: ${RefineSchemaTypeFromModelType(field.type, field.schemaType!)}`;
+    });
+    nestedPathTypeDefinitions += `export const ${nestedPath.name}Type = {
+  ${nestedPathFields.join(",\n")},\n};\n\n`;
+  }
+  result = result.replace(/\/\/NestedPathTypeDefinitions/g, nestedPathTypeDefinitions);
+
+  // generate subdocument schemas
+  let subdocumentSchemas = "";
+  for (const subdocument of modelSchemaInput.subdocumentBases ?? []) {
+    let subdocumentFields = subdocument.fields.map((field) => {
+      return `${field.name}: ${RefineSchemaTypeFromModelType(field.type, field.schemaType!)}`;
+    });
+    subdocumentSchemas += `export const ${subdocument.name}Schema = new Schema<${subdocument.name}, Model<${subdocument.name}>, ${subdocument.name}>({
+  ${subdocumentFields.join(",\n")},\n});\n\n`;
+  }
+  result = result.replace(/\/\/SubdocumentBaseSchemaDefinitions/g, subdocumentSchemas);
+
+  const filename = toKebabCase(modelSchemaInput.name);
+  const distFolder = path.join(__dirname, "../dist/schemas");
+  if (!fs.existsSync(distFolder)) {
+    fs.mkdirSync(distFolder, { recursive: true });
+  }
+
+  const distFilePath = path.join(distFolder, `${filename}.ts`);
+  fs.writeFileSync(distFilePath, result);
+
+  return result;
+};

--- a/data-access-generator/src/templates/aggregate-root/aggregate-root-helpers.ts
+++ b/data-access-generator/src/templates/aggregate-root/aggregate-root-helpers.ts
@@ -156,7 +156,7 @@ export const AggregateRootGenerateNestedPathFieldGetters = (aggregateRootInputSt
     }\n`;
       } else {
         result += `  get ${field.name}(): ${typeWithVersionIfAny} {
-      return new ${typeWithVersionIfAny}(this.props.${field.name}
+      return new ${typeWithVersionIfAny}(this.props.${field.name}, this.context
       //, this.visa
       );
     }\n`;

--- a/data-access-generator/src/templates/schema-template.txt
+++ b/data-access-generator/src/templates/schema-template.txt
@@ -1,0 +1,12 @@
+//Nested Path Type definitions
+//NestedPathTypeDefinitions
+
+//SubdocumentBase Definitions
+//SubdocumentBaseSchemaDefinitions
+
+export const ModelNameSchema = new Schema<ModelName, Model<ModelName>, ModelName>({
+  //FieldDefinitions
+  schemaVersion: { type: String, required: false, default: "1.0.0" },
+});
+
+export const ModelNameModel = model<ModelName>("ModelName", ModelNameSchema);


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add functionality to generate schema definitions from model schema inputs and refactor the code to streamline the data access and schema generation process. Introduce a new raw input for `CredentialVerificationCase` with detailed schema definitions.

New Features:
- Introduce a new function `GenerateSchemaDefinitions` to generate schema definitions from model schema input structures.
- Add a new raw input file for `CredentialVerificationCase` with comprehensive schema definitions and nested path interfaces.

Enhancements:
- Refactor the code to use a new `StartPainKilling` function to streamline the process of generating data access and schema definitions for various raw inputs.
- Improve the `RefineGraphqlTypeFromModelType` function by renaming the parameter for clarity and consistency.
- Enhance logging in the `DataAccessPainKiller` function to include the name of the input structure being processed.

<!-- Generated by sourcery-ai[bot]: end summary -->