### PR TITLE
Fixed bug in seedwork for removing elements from prop array

### DIFF
--- a/data-access/seedwork/services-seedwork-datastore-mongodb/infrastructure/mongo-domain-adapter.ts
+++ b/data-access/seedwork/services-seedwork-datastore-mongodb/infrastructure/mongo-domain-adapter.ts
@@ -22,7 +22,7 @@ export class MongoosePropArray<propType extends DomainEntityProps, docType exten
     return this.docArray[itemId] as any as propType;
   }
   removeItem(item: propType): void {
-    this.docArray.pull({_id:item['doc']['_id'] } );
+    this.docArray.pull({_id:item['props']['_id'] } );
   }
   removeAll(): void {
     const ids = this.docArray.map((doc) => doc._id);


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a bug in the MongoosePropArray class by updating the removeItem method to correctly reference the '_id' property from 'props' instead of 'doc' when removing elements from the document array.

Bug Fixes:
- Correct the property reference in the removeItem method to use 'props' instead of 'doc' for identifying elements to remove from the document array.

<!-- Generated by sourcery-ai[bot]: end summary -->