### PR TITLE
Update SonarCloud tasks to version 2

### DIFF
--- a/data-access/build-pipeline/core/function-app-build-stage.yml
+++ b/data-access/build-pipeline/core/function-app-build-stage.yml
@@ -98,7 +98,7 @@ stages:
         path: ${{parameters.SONAR_USER_HOME}}/cache
 
     # Set up SonarCloud
-    - task: SonarCloudPrepare@1
+    - task: SonarCloudPrepare@2
       displayName: 'SonarCloud: Prepare analysis configuration'
       condition: and(succeeded(), eq(${{parameters.disableSonarCloudTasks}}, False))
       inputs:
@@ -113,12 +113,12 @@ stages:
           sonar.javascript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/data-access/coverage/lcov.info
         
     # SonarCloud: Analyze code and code coverage
-    - task: SonarCloudAnalyze@1
+    - task: SonarCloudAnalyze@2
       displayName: 'SonarCloud: Run analysis'
       condition: and(succeeded(), eq(${{parameters.disableSonarCloudTasks}}, False))
 
     # SonarCloud: Publish analysis results and wait until completion
-    - task: SonarCloudPublish@1
+    - task: SonarCloudPublish@2
       displayName: 'SonarCloud: Publish results on build summary'
       condition: and(succeeded(), eq(${{parameters.disableSonarCloudTasks}}, False))
       inputs:

--- a/ui-community/azure-pipelines.yml
+++ b/ui-community/azure-pipelines.yml
@@ -131,6 +131,14 @@ stages:
         pathToPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'www'
         publishLocation: 'Container'
+        
+    # SonarCloud: Break the build if it doesn't pass the Quality Gate
+    - task: sonarcloud-buildbreaker@2
+      displayName: 'SonarCloud: Break the build if it does not pass the Quality'
+      condition: and(succeeded(), eq(${{parameters.disableSonarCloudTasks}}, False))
+      inputs:
+        SonarCloud: ${{parameters.SonarCloud}}
+        organization: ${{parameters.SonarCloud_organization}}
 
 - stage: build_prd_stage
   displayName: Build prd Stage

--- a/ui-community/azure-pipelines.yml
+++ b/ui-community/azure-pipelines.yml
@@ -22,6 +22,7 @@ pr:
 variables:
 ## PROJECT SPECIFIC VARIABLES - start
     PROJECT_NAME: 'ui-community'
+    disableSonarCloudTasks: 'false'
     SONARCLOUD_PROJECT_KEY: 'oc-ui'
     SONARCLOUD_PROJECT_NAME: 'oc-ui'
     vmImageName: 'ubuntu-latest'
@@ -131,7 +132,7 @@ stages:
         pathToPublish: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'www'
         publishLocation: 'Container'
-        
+
     # SonarCloud: Break the build if it doesn't pass the Quality Gate
     - task: sonarcloud-buildbreaker@2
       displayName: 'SonarCloud: Break the build if it does not pass the Quality'


### PR DESCRIPTION
This pull request updates the SonarCloud tasks in the azure-pipelines.yml file to version 2. The tasks that are updated include SonarCloudPrepare, SonarCloudAnalyze, and SonarCloudPublish. Additionally, a new task, sonarcloud-buildbreaker, is added to break the build if it does not pass the Quality Gate.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update SonarCloud tasks in the CI pipeline to version 2 and introduce a build breaker task to enforce Quality Gate compliance.

CI:
- Update SonarCloud tasks in the azure-pipelines.yml file to version 2, including SonarCloudPrepare, SonarCloudAnalyze, and SonarCloudPublish.
- Add a new SonarCloud task, sonarcloud-buildbreaker, to break the build if it does not pass the Quality Gate.

<!-- Generated by sourcery-ai[bot]: end summary -->