### PR TITLE
Exclude generated.tsx from SonarCloud analysis

### DIFF
--- a/ui-community/azure-pipelines.yml
+++ b/ui-community/azure-pipelines.yml
@@ -101,6 +101,8 @@ stages:
         cliProjectKey: $(SONARCLOUD_PROJECT_KEY)
         cliProjectName: $(SONARCLOUD_PROJECT_NAME)
         cliSources: './$(PROJECT_NAME)/src'
+        extraProperties: |
+          sonar.exclusions=**/src/generated.tsx
 
     
         # Publish chromatic


### PR DESCRIPTION
This pull request excludes the file `generated.tsx` from the SonarCloud analysis. This change ensures that the file is not considered during the analysis process.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Exclude `generated.tsx` from SonarCloud analysis by updating the Azure Pipelines configuration to add it to the sonar exclusions.

CI:
- Exclude the file `generated.tsx` from SonarCloud analysis by adding it to the exclusions in the Azure Pipelines configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->