### PR TITLE
Fix violation ticket audit

### DIFF
--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
@@ -3,6 +3,8 @@ import { DomainExecutionContext } from '../../../../domain-execution-context';
 import { ViolationTicketV1Visa } from './violation-ticket.visa';
 import { Member, MemberEntityReference, MemberProps } from '../../../community/member/member';
 import * as ValueObjects from './activity-detail.value-objects';
+import { Audit } from '../../../../../../domain/decorators';
+import { AuditContextFactoryType } from '../../../../../../init/audit-context';
 
 export interface ActivityDetailPropValues extends DomainEntityProps {
   activityType: string;
@@ -43,5 +45,10 @@ export class ActivityDetail extends DomainEntity<ActivityDetailProps> implements
 
   set ActivityBy(activityBy: MemberEntityReference) {
     this.props.setActivityByRef(activityBy);
+  }
+
+  @Audit
+  setActivityBy(AuditContextFactory?: AuditContextFactoryType) {
+    this.props.setActivityByRef(AuditContextFactory.getMemberRef);
   }
 }

--- a/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
@@ -29,7 +29,7 @@ import { FinanceReferenceProps } from '../../../../../../../app/domain/contexts/
 import { ApprovalProps } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/finance-details-adhoc-transactions-approval';
 import { ViolationTicketV1Visa } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/violation-ticket.visa';
 import { InfrastructureContext } from '../../../../../../../app/init/infrastructure-context';
-import { AuditContextFactory } from '../../../../../../../app/init/audit-context';
+import { AuditContextFactory, FuncToGetMemberRefFromAuditContextFactory } from '../../../../../../../app/init/audit-context';
 
 export class ViolationTicketV1Converter extends MongoTypeConverter<
   DomainExecutionContext,

--- a/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
@@ -29,6 +29,7 @@ import { FinanceReferenceProps } from '../../../../../../../app/domain/contexts/
 import { ApprovalProps } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/finance-details-adhoc-transactions-approval';
 import { ViolationTicketV1Visa } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/violation-ticket.visa';
 import { InfrastructureContext } from '../../../../../../../app/init/infrastructure-context';
+import { AuditContextFactory } from '../../../../../../../app/init/audit-context';
 
 export class ViolationTicketV1Converter extends MongoTypeConverter<
   DomainExecutionContext,
@@ -195,8 +196,8 @@ export class ActivityDetailDomainAdapter implements ActivityDetailProps {
       return new MemberDomainAdapter(this.props.activityBy, this.infrastructureContext);
     }
   }
-  public setActivityByRef(activityBy: MemberEntityReference) {
-    this.props.set('activityBy', activityBy['props']['doc']);
+  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
+    this.props.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
   }
 }
 
@@ -610,4 +611,3 @@ export class ViolationTicketV1RevisionRequestedChangesDomainAdapter implements V
     this.doc.requestUpdatedPaymentTransaction = requestUpdatedPaymentTransaction;
   }
 }
-


### PR DESCRIPTION
Related to #301

Add `Audit` decorator to set `activityBy` in the activity log of the violation-ticket domain model.

* **data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts**
  - Add `@Audit` decorator to `setActivityBy` method.
  - Update `setActivityBy` method to accept `AuditContextFactoryType` as an argument.
  - Use `AuditContextFactoryType` to set `activityBy` in `setActivityBy` method.

* **data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts**
  - Import `AuditContextFactory` from `data-access/src/app/init/audit-context`.
  - Update `ActivityDetailDomainAdapter` class to use `AuditContextFactory` to set `activityBy` in `setActivityByRef` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simnova/ownercommunity/issues/301?shareId=29c3a277-b064-4ee0-88b9-9f8babfcfda2).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the violation ticket audit by adding an `Audit` decorator and updating methods to use `AuditContextFactory` for setting `activityBy` in the activity log.

Bug Fixes:
- Fix the violation ticket audit by adding an `Audit` decorator to ensure `activityBy` is correctly set in the activity log.

Enhancements:
- Update the `setActivityBy` method to accept `AuditContextFactoryType` as an argument for improved context handling.

<!-- Generated by sourcery-ai[bot]: end summary -->