### PR TITLE
Fix audit info for violation ticket

### DIFF
--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts
@@ -3,12 +3,14 @@ import { DomainExecutionContext } from '../../../../domain-execution-context';
 import { ViolationTicketV1Visa } from './violation-ticket.visa';
 import { Member, MemberEntityReference, MemberProps } from '../../../community/member/member';
 import * as ValueObjects from './activity-detail.value-objects';
+import { Audit } from '../../../../decorators';
+import { AuditContextFactoryType, FuncToGetMemberRefFromAuditContextFactory } from '../../../../../init/audit-context';
 
 export interface ActivityDetailPropValues extends DomainEntityProps {
   activityType: string;
   activityDescription: string;
   readonly activityBy: MemberProps;
-  setActivityByRef: (activityBy: MemberEntityReference) => void;
+  setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory);
 }
 
 export interface ActivityDetailProps extends ActivityDetailPropValues {}
@@ -41,7 +43,8 @@ export class ActivityDetail extends DomainEntity<ActivityDetailProps> implements
     this.props.activityDescription = new ValueObjects.Description(activityDescription).valueOf();
   }
 
-  set ActivityBy(activityBy: MemberEntityReference) {
-    this.props.setActivityByRef(activityBy);
+  @Audit
+  setActivityBy(AuditContextFactory?: AuditContextFactoryType) {
+    this.props.setActivityByRef(AuditContextFactory.getMemberRef);
   }
 }

--- a/data-access/src/app/domain/contexts/cases/violation-ticket/v1/violation-ticket.ts
+++ b/data-access/src/app/domain/contexts/cases/violation-ticket/v1/violation-ticket.ts
@@ -113,7 +113,7 @@ export class ViolationTicketV1<props extends ViolationTicketV1Props> extends Agg
     let newActivity = violationTicket.requestNewActivityDetail();
     newActivity.ActivityType = ActivityDetailValueObjects.ActivityTypeCodes.Created;
     newActivity.ActivityDescription = 'Created';
-    newActivity.ActivityBy = requestor;
+    newActivity.setActivityBy();
     violationTicket.financeDetails.ServiceFee = penaltyAmount;
     return violationTicket;
   }
@@ -378,7 +378,7 @@ export class ViolationTicketV1<props extends ViolationTicketV1Props> extends Agg
     const activityDetail = this.requestNewActivityDetail();
     activityDetail.ActivityType = ActivityDetailValueObjects.ActivityTypeCodes.Updated;
     activityDetail.ActivityDescription = description;
-    activityDetail.ActivityBy = by;
+    activityDetail.setActivityBy();
   }
 
   public requestAddMessage(message: string, sentBy: string, embedding: string, initiatedBy?: MemberEntityReference): void {
@@ -419,7 +419,7 @@ export class ViolationTicketV1<props extends ViolationTicketV1Props> extends Agg
     const activityDetail = this.requestNewActivityDetail();
     activityDetail.ActivityDescription = description;
     activityDetail.ActivityType = this.statusMappings.get(newStatus.valueOf());
-    activityDetail.ActivityBy = by;
+    activityDetail.setActivityBy();
   }
 
   public override onSave(isModified: boolean): void {

--- a/data-access/src/infrastructure-services-impl/datastore/memorydb/infrastructure/cases/violation-ticket/v1/violation-ticket.memory-repository.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/memorydb/infrastructure/cases/violation-ticket/v1/violation-ticket.memory-repository.ts
@@ -54,8 +54,8 @@ class MemoryActivityDetail extends MemoryBaseAdapter implements ActivityDetailPr
   activityType: string;
   activityDescription: string;
   activityBy: MemberProps;
-  setActivityByRef(activityBy: MemberEntityReference): void {
-    this.activityBy = activityBy['props'] as MemberProps;
+  setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory): void {
+    // empty implementation
   }
 }
 

--- a/data-access/src/infrastructure-services-impl/datastore/memorydb/infrastructure/cases/violation-ticket/v1/violation-ticket.memory-repository.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/memorydb/infrastructure/cases/violation-ticket/v1/violation-ticket.memory-repository.ts
@@ -19,6 +19,7 @@ import { ViolationTicketV1RevisionRequestedChangesProps } from '../../../../../.
 import { RevenueRecognitionProps } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/finance-detail-revenue-recognition';
 import { ViolationTicketV1Visa } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/violation-ticket.visa';
 import { InfrastructureContext } from '../../../../../../../app/init/infrastructure-context';
+import { FuncToGetMemberRefFromAuditContextFactory } from '../../../../../../../app/init/audit-context';
 
 class MemoryViolationTicketV1RevisionRequestedChanges implements ViolationTicketV1RevisionRequestedChangesProps {
   requestUpdatedAssignment: boolean;

--- a/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
@@ -29,6 +29,7 @@ import { FinanceReferenceProps } from '../../../../../../../app/domain/contexts/
 import { ApprovalProps } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/finance-details-adhoc-transactions-approval';
 import { ViolationTicketV1Visa } from '../../../../../../../app/domain/contexts/cases/violation-ticket/v1/violation-ticket.visa';
 import { InfrastructureContext } from '../../../../../../../app/init/infrastructure-context';
+import { FuncToGetMemberRefFromAuditContextFactory } from '../../../../../../../app/init/audit-context';
 
 export class ViolationTicketV1Converter extends MongoTypeConverter<
   DomainExecutionContext,
@@ -195,8 +196,8 @@ export class ActivityDetailDomainAdapter implements ActivityDetailProps {
       return new MemberDomainAdapter(this.props.activityBy, this.infrastructureContext);
     }
   }
-  public setActivityByRef(activityBy: MemberEntityReference) {
-    this.props.set('activityBy', activityBy['props']['doc']);
+  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
+    this.props.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
   }
 }
 
@@ -610,4 +611,3 @@ export class ViolationTicketV1RevisionRequestedChangesDomainAdapter implements V
     this.doc.requestUpdatedPaymentTransaction = requestUpdatedPaymentTransaction;
   }
 }
-

--- a/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
@@ -169,10 +169,6 @@ export class ViolationTicketV1DomainAdapter extends MongooseDomainAdapter<Violat
     }
     return new FinanceDetailDomainAdapter(this.doc.financeDetails, this.infrastructureContext);
   }
-
-  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
-    this.doc.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
-  }
 }
 
 export class ActivityDetailDomainAdapter implements ActivityDetailProps {
@@ -200,8 +196,8 @@ export class ActivityDetailDomainAdapter implements ActivityDetailProps {
       return new MemberDomainAdapter(this.props.activityBy, this.infrastructureContext);
     }
   }
-  public setActivityByRef(activityBy: MemberEntityReference) {
-    this.props.set('activityBy', activityBy['props']['doc']);
+  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
+    this.props.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
   }
 }
 

--- a/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
+++ b/data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts
@@ -169,6 +169,10 @@ export class ViolationTicketV1DomainAdapter extends MongooseDomainAdapter<Violat
     }
     return new FinanceDetailDomainAdapter(this.doc.financeDetails, this.infrastructureContext);
   }
+
+  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
+    this.doc.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
+  }
 }
 
 export class ActivityDetailDomainAdapter implements ActivityDetailProps {
@@ -196,8 +200,8 @@ export class ActivityDetailDomainAdapter implements ActivityDetailProps {
       return new MemberDomainAdapter(this.props.activityBy, this.infrastructureContext);
     }
   }
-  public setActivityByRef(funcToGetMemberRef: FuncToGetMemberRefFromAuditContextFactory) {
-    this.props.set('activityBy', funcToGetMemberRef(this.infrastructureContext.auditContext));
+  public setActivityByRef(activityBy: MemberEntityReference) {
+    this.props.set('activityBy', activityBy['props']['doc']);
   }
 }
 


### PR DESCRIPTION
Fixes #305

Add audit info for Violation Ticket in the infrastructure tier bypassing the domain model.

* **Domain Model Updates:**
  - Import `Audit`, `AuditContextFactoryType`, and `FuncToGetMemberRefFromAuditContextFactory` in `data-access/src/app/domain/contexts/cases/violation-ticket/v1/activity-detail.ts`.
  - Add `setActivityByRef` method with a `funcToGetMemberRef` parameter.
  - Add `setActivityBy` method with an optional `AuditContextFactory` parameter and `@Audit` decorator.

* **Infrastructure Implementation Updates:**
  - Add `setActivityByRef` method to `ActivityDetailDomainAdapter` class in `data-access/src/infrastructure-services-impl/datastore/mongodb/infrastructure/cases/violation-ticket/v1/violation-ticket.domain-adapter.ts`.
  - Implement `setActivityByRef` method to set `activityBy` property using `funcToGetMemberRef` parameter.
  - Import `FuncToGetMemberRefFromAuditContextFactory`.

* **In-memory Implementation Updates:**
  - Add `setActivityByRef` method to `MemoryActivityDetail` class in `data-access/src/infrastructure-services-impl/datastore/memorydb/infrastructure/cases/violation-ticket/v1/violation-ticket.memory-repository.ts`.
  - Implement `setActivityByRef` method with an empty implementation.

* **Reference Updates:**
  - Replace all references to `ActivityBy` setter of `ActivityDetail` class with a call to `setActivityBy` method in `data-access/src/app/domain/contexts/cases/violation-ticket/v1/violation-ticket.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simnova/ownercommunity/issues/305?shareId=27194c83-f56e-49cb-8def-6860f6920bb7).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix audit information handling for Violation Ticket by introducing a new method to set activity references using a function parameter, and update the domain and infrastructure layers to use this method.

Bug Fixes:
- Fix audit information handling for Violation Ticket by bypassing the domain model.

Enhancements:
- Introduce `setActivityByRef` method in domain, infrastructure, and in-memory implementations to handle activity reference setting using a function parameter.
- Replace direct `ActivityBy` setter calls with `setActivityBy` method calls across the Violation Ticket domain.

<!-- Generated by sourcery-ai[bot]: end summary -->