### PR TITLE
Added duplicate check for ObjectTypeExtensionNode

### DIFF
--- a/data-access/src/functions/http-graphql/schema/builder/check-duplicate-types.ts
+++ b/data-access/src/functions/http-graphql/schema/builder/check-duplicate-types.ts
@@ -19,6 +19,9 @@ const GRAPHQL_FILES_PATTERN = path.join(__dirname, "../../../http-graphql/**/*.g
 console.log(`... graphql-file-pattern | ${GRAPHQL_FILES_PATTERN}`);
 
 
+// [TODO] sourcery suggestion: https://github.com/simnova/ownercommunity/pull/316#discussion_r1783529777
+
+
 // extension types
 function processExtensionTypeNode(outputTypeNode: AllowedExtensionTypeDefinitionNode, processedNodes: string[] = [], errors: string[] = []) {
     const fieldDefinitions = recursiveFunctionToFindExtensionFieldDefinitions(outputTypeNode);


### PR DESCRIPTION
This pull request fixes a duplicate check issue for the `ObjectTypeExtensionNode`. Previously, the code was not properly checking for duplicates when processing extension types. This PR adds a new function `processExtensionTypeNode` to handle extension types and ensures that duplicate fields are properly detected.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue of not detecting duplicate fields in ObjectTypeExtensionNode by introducing a new function to process extension types and updating the logic to check for duplicates.

Bug Fixes:
- Fix duplicate check for ObjectTypeExtensionNode by adding a new function to handle extension types and ensure duplicate fields are detected.

<!-- Generated by sourcery-ai[bot]: end summary -->