### PR TITLE
Refactor Apollo connection and add removeTypename link

### DIFF
--- a/ui-community/package-lock.json
+++ b/ui-community/package-lock.json
@@ -26,6 +26,7 @@
         "@vitest/coverage-v8": "^1.2.2",
         "antd": "^5.4.7",
         "antd-img-crop": "^4.12.2",
+        "apollo-link-rest": "^0.9.0",
         "async-retry": "^1.3.3",
         "axios": "^1.6.7",
         "axios-cache-interceptor": "^1.5.1",
@@ -7656,6 +7657,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo-link-rest": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-link-rest/-/apollo-link-rest-0.9.0.tgz",
+      "integrity": "sha512-kuXjR56Y12w0TZcqwVaONKlipB6g3Ya1dAy4NMCaylPpNXq6tO+qzQFPUyDJC7B0JoJPIFjxPV2rAet4uGM4UQ==",
+      "peerDependencies": {
+        "@apollo/client": ">=3",
+        "graphql": ">=0.11",
+        "qs": ">=6"
+      }
+    },
     "node_modules/app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
@@ -8457,7 +8468,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -14305,7 +14315,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15429,7 +15438,6 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -17261,7 +17269,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
       "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "function-bind": "^1.1.2",
@@ -17333,7 +17340,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/ui-community/package.json
+++ b/ui-community/package.json
@@ -22,6 +22,7 @@
     "@vitest/coverage-v8": "^1.2.2",
     "antd": "^5.4.7",
     "antd-img-crop": "^4.12.2",
+    "apollo-link-rest": "^0.9.0",
     "async-retry": "^1.3.3",
     "axios": "^1.6.7",
     "axios-cache-interceptor": "^1.5.1",

--- a/ui-community/src/App.tsx
+++ b/ui-community/src/App.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 import './App.css';
-import ApolloConnection from './components/shared/apollo-connection';
+import { ApolloConnection } from './components/shared/apollo-connection';
 import { Accounts } from './components/layouts/accounts';
 import { Admin } from './components/layouts/admin';
 import { Members } from './components/layouts/members';

--- a/ui-community/src/components/editor/components/country-info.tsx
+++ b/ui-community/src/components/editor/components/country-info.tsx
@@ -27,7 +27,10 @@ export const CountryInfo = () => {
   
   const [loadCountry, { called, loading, data, error }] = useLazyQuery(
     GET_COUNTRY_DETAILS,
-    { variables: { country: country},context: { clientName: 'country' } },    
+    { 
+      variables: { country: country},
+      // context: { clientName: 'country' } 
+    },    
   );
 
   if (called && loading) return <>Loading...</>;

--- a/ui-community/src/components/editor/components/country-info2.tsx
+++ b/ui-community/src/components/editor/components/country-info2.tsx
@@ -35,7 +35,10 @@ const CountryInfo2: any = ({country, ...props} : CountryInfo2Prop ) => {
   
   const { loading, data, error } = useQuery(
     GET_COUNTRY_DETAILS,
-    { variables: { country: country}, context: { clientName: 'country' } }
+    { 
+      variables: { country: country}, 
+      // context: { clientName: 'country' } 
+    }
   );
 
   useEditor((state) => ({

--- a/ui-community/src/components/layouts/shared/components/properties-listing.container.tsx
+++ b/ui-community/src/components/layouts/shared/components/properties-listing.container.tsx
@@ -36,29 +36,13 @@ export const PropertiesListingContainer: React.FC<PropertiesListingContainerProp
     }
   });
 
-  function stripTypenames(obj: any, propToDelete: string) {
-    let tempObj = JSON.parse(JSON.stringify(obj));
-    for (const property in tempObj) {
-      if (typeof tempObj[property] === 'object' && !(tempObj[property] instanceof File)) {
-        delete tempObj.property;
-        const newData = stripTypenames(tempObj[property], propToDelete);
-        tempObj[property] = newData;
-      } else if (property === propToDelete) {
-        delete tempObj[property];
-      }
-    }
-    return tempObj;
-  }
 
 
   const handleSave = async (values: PropertyUpdateInput) => {
-    let original = values;
-    let stripped = stripTypenames(values, '__typename');
-    console.log(original, stripped);
     try {
       await updateProperty({
         variables: {
-          input: stripped
+          input: values
         }
       });
       message.success('Saved');

--- a/ui-community/src/components/shared/apollo-client-links.tsx
+++ b/ui-community/src/components/shared/apollo-client-links.tsx
@@ -19,8 +19,18 @@ export const BaseApolloLink = (): ApolloLink => setContext(async (_, { headers }
   };
 });
 
-
-export const ApolloLinkToAddAuthHeader = (auth: AuthContextProps): ApolloLink => new ApolloLink((operation, forward) => {;
+export const ApolloLinkToAddAuthHeader = (auth: AuthContextProps): ApolloLink => 
+  setContext(async (_, { headers }) => {
+    const access_token = auth.isAuthenticated ? auth.user?.access_token : undefined;
+    return {
+      headers: {
+        ...headers,
+        ...(access_token && { Authorization: `Bearer ${access_token}` })
+      }
+    };
+  });
+// alternate way to add auth header
+export const ApolloLinkToAddAuthHeader1 = (auth: AuthContextProps): ApolloLink => new ApolloLink((operation, forward) => {;
   const access_token = (auth.isAuthenticated) ? auth.user?.access_token : undefined;
   if(!access_token) {
     return forward(operation);
@@ -31,7 +41,7 @@ export const ApolloLinkToAddAuthHeader = (auth: AuthContextProps): ApolloLink =>
   });
   return forward(operation);
 });
-// in case apolloLinkToAddAuthHeader does not work
+// alternate way to add auth header
 export const ApolloLinkToAddAuthHeader2 = (auth: AuthContextProps): ApolloLink => {
   return setContext(async (_, { headers }) => { 
     const returnHeaders = { ...headers };

--- a/ui-community/src/components/shared/apollo-client-links.tsx
+++ b/ui-community/src/components/shared/apollo-client-links.tsx
@@ -1,0 +1,69 @@
+import { ApolloClient, ApolloLink, DefaultContext, InMemoryCache, from } from '@apollo/client';
+import { BatchHttpLink } from '@apollo/client/link/batch-http';
+import { AuthContextProps } from 'react-oidc-context';
+import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename';
+import { setContext } from '@apollo/client/link/context';
+
+
+export const client = new ApolloClient({
+  cache: new InMemoryCache(),
+  connectToDevTools: import.meta.env.NODE_ENV !== 'production'
+});
+
+
+export const BaseApolloLink = (): ApolloLink => setContext(async (_, { headers }) => {
+  return {
+    headers: {
+      ...headers
+    }
+  };
+});
+
+
+export const ApolloLinkToAddAuthHeader = (auth: AuthContextProps): ApolloLink => new ApolloLink((operation, forward) => {;
+  const access_token = (auth.isAuthenticated === true) ? auth.user?.access_token : undefined;
+  if(!access_token) {
+    return forward(operation);
+  }
+  operation.setContext(async (prevContext: DefaultContext) => { 
+    prevContext.headers["Authorization"] = `Bearer ${access_token}`;
+    return prevContext;
+  });
+  return forward(operation);
+});
+// in case apolloLinkToAddAuthHeader does not work
+export const ApolloLinkToAddAuthHeader2 = (auth: AuthContextProps): ApolloLink => {
+  return setContext(async (_, { headers }) => { 
+    const returnHeaders = { ...headers };
+    const access_token = (auth.isAuthenticated === true) ? auth.user?.access_token : undefined;
+    console.log(`apolloLinkToAddAuthHeader > access_token : ${access_token}`);
+    if (access_token) {
+      returnHeaders['Authorization'] = `Bearer ${access_token}`;
+    }
+    return { headers: returnHeaders };
+  });
+};
+
+
+export const ApolloLinkToAddCustomHeader = (headerName: string, headerValue: string | null | undefined, ifTrue?: boolean): ApolloLink => new ApolloLink((operation, forward) => {
+  if(!headerValue || (ifTrue !== undefined && ifTrue === false)) {
+    return forward(operation);
+  }
+  operation.setContext(async (prevContext: DefaultContext) => { 
+    prevContext.headers[headerName] = headerValue;
+    return prevContext;
+  });
+  return forward(operation);
+});
+
+
+// includes removeTypenameFromVariables link
+export const TerminatingApolloLinkForGraphqlServer= (config: BatchHttpLink.Options) => {
+  const batchHttpLink = new BatchHttpLink({
+    uri: config.uri,
+    batchMax: config.batchMax, // No more than 15 operations per batch
+    batchInterval: config.batchInterval // Wait no more than 50ms after first batched operation
+  });
+  return from([removeTypenameFromVariables(), batchHttpLink]);
+};
+

--- a/ui-community/src/components/shared/apollo-client-links.tsx
+++ b/ui-community/src/components/shared/apollo-client-links.tsx
@@ -21,7 +21,7 @@ export const BaseApolloLink = (): ApolloLink => setContext(async (_, { headers }
 
 
 export const ApolloLinkToAddAuthHeader = (auth: AuthContextProps): ApolloLink => new ApolloLink((operation, forward) => {;
-  const access_token = (auth.isAuthenticated === true) ? auth.user?.access_token : undefined;
+  const access_token = (auth.isAuthenticated) ? auth.user?.access_token : undefined;
   if(!access_token) {
     return forward(operation);
   }
@@ -36,7 +36,6 @@ export const ApolloLinkToAddAuthHeader2 = (auth: AuthContextProps): ApolloLink =
   return setContext(async (_, { headers }) => { 
     const returnHeaders = { ...headers };
     const access_token = (auth.isAuthenticated === true) ? auth.user?.access_token : undefined;
-    console.log(`apolloLinkToAddAuthHeader > access_token : ${access_token}`);
     if (access_token) {
       returnHeaders['Authorization'] = `Bearer ${access_token}`;
     }

--- a/ui-community/src/components/shared/apollo-connection.tsx
+++ b/ui-community/src/components/shared/apollo-connection.tsx
@@ -45,7 +45,7 @@ export const ApolloConnection: FC<ApolloConnectionProps> = (props: ApolloConnect
   ]);
 
   const updateLink = () => {
-    const link = ApolloLink.split(
+    return ApolloLink.split(
       // various options to split:
       // 1. use a custom property in context: (operation) => operation.getContext().dataSource === DataSourceEnum.country,
       // 2. check for string name of the query if it is named: (operation) => operation.operationName === "CountryDetails",
@@ -55,9 +55,6 @@ export const ApolloConnection: FC<ApolloConnectionProps> = (props: ApolloConnect
       // and make the graphql link the default
       dataSources.get(DataSourceEnum.graphql)
     ) as ApolloLink;
-
-    console.log(`updateLink > link : ${JSON.stringify(link)}`);
-    return link;
   };
   
   client.setLink(updateLink());

--- a/ui-community/src/components/shared/apollo-connection.tsx
+++ b/ui-community/src/components/shared/apollo-connection.tsx
@@ -1,74 +1,70 @@
-import { FC, useEffect } from 'react';
-
-import { ApolloClient, ApolloLink, ApolloProvider, HttpLink, InMemoryCache, from } from '@apollo/client';
-
-import { BatchHttpLink } from '@apollo/client/link/batch-http';
-import { setContext } from '@apollo/client/link/context';
-import { useAuth } from 'react-oidc-context';
-import { useParams } from 'react-router-dom';
-
-const countryLink = new HttpLink({
-  uri: 'https://countries.trevorblades.com/'
-});
+import { from, ApolloLink, ApolloProvider } from "@apollo/client";
+import { RestLink } from 'apollo-link-rest';
+import { FC, useEffect } from "react";
+import { useAuth } from "react-oidc-context";
+import { useParams } from "react-router-dom";
+import { ApolloLinkToAddAuthHeader, ApolloLinkToAddCustomHeader, client, BaseApolloLink, TerminatingApolloLinkForGraphqlServer } from "./apollo-client-links";
 
 
-const httpLink = new BatchHttpLink({
-  uri: `${import.meta.env.VITE_FUNCTION_ENDPOINT}`,
-  batchMax: 15, // No more than 15 operations per batch
-  batchInterval: 50 // Wait no more than 50ms after first batched operation
-});
+export enum DataSourceEnum {
+  country = 'country',
+  graphql = 'graphql'
+}
 
-const client = new ApolloClient({
-  cache: new InMemoryCache(),
-  connectToDevTools: import.meta.env.NODE_ENV !== 'production'
-});
-
-const ApolloConnection: FC<any> = (props) => {
+export interface ApolloConnectionProps {
+  children: React.ReactNode;
+}
+export const ApolloConnection: FC<ApolloConnectionProps> = (props: ApolloConnectionProps) => {
   const auth = useAuth();
   const params = useParams(); // useParams.memberId won't work here because ApolloConnection wraps the Routes, not inside a Route
+  const communityId = params['*']?.slice(0, 24) ?? null;
+  const memberId = params['*']?.match(/(member|admin)\/([\w\d]+)/)?.[2] ?? null;
 
-  const withToken = setContext(async (_, { headers }) => {
-      return getAuthHeaders(headers);
-   
-  });
 
-  const getAuthHeaders = async (headers: any) => {
-    if(auth.isAuthenticated !== true) {
-      return {
-        headers: {
-          ...headers
-        }
-      };
-    }
-    const access_token = auth.user?.access_token;
-    console.log('auth-token', access_token);
-    const returnHeaders = { ...headers };
-    if (access_token) {
-      returnHeaders['Authorization'] = `Bearer ${access_token}`;
-    }
-    console.log('params ', params['*']?.slice(0, 24));
-    const communityId = params['*']?.slice(0, 24) ?? null;
-    if (communityId !== null && communityId !== 'accounts') {
-      returnHeaders['community'] = communityId;
-    }
-    const memberId = params['*']?.match(/(member|admin)\/([\w\d]+)/)?.[2] ?? null;
-    if (memberId !== null) {
-      returnHeaders['member'] = memberId;
-    }
-    console.log('returnHeaders', returnHeaders);
-    return { headers: returnHeaders };
+  const apolloLinkChainForGraphqlDataSource = from([
+    BaseApolloLink(),
+    ApolloLinkToAddAuthHeader(auth),
+    ApolloLinkToAddCustomHeader('community', communityId, (communityId !== 'accounts')),
+    ApolloLinkToAddCustomHeader('member', memberId),
+    TerminatingApolloLinkForGraphqlServer({
+      uri: `${import.meta.env.VITE_FUNCTION_ENDPOINT}`,
+      batchMax: 15,
+      batchInterval: 50
+    })
+  ]);
+
+  const apolloLinkChainForCountryDataSource = from([
+    new RestLink({
+      uri: 'https://countries.trevorblades.com/'
+    })
+  ]);
+
+  const dataSources = new Map<DataSourceEnum, ApolloLink>([
+    [DataSourceEnum.country, apolloLinkChainForCountryDataSource],
+    [DataSourceEnum.graphql, apolloLinkChainForGraphqlDataSource]
+  ]);
+
+  const updateLink = () => {
+    const link = ApolloLink.split(
+      // various options to split:
+      // 1. use a custom property in context: (operation) => operation.getContext().dataSource === DataSourceEnum.country,
+      // 2. check for string name of the query if it is named: (operation) => operation.operationName === "CountryDetails",
+      (operation) => operation.operationName === "CountryDetails",
+      dataSources.get(DataSourceEnum.country)!,
+      // you can add more nested split links here
+      // and make the graphql link the default
+      dataSources.get(DataSourceEnum.graphql)
+    ) as ApolloLink;
+
+    console.log(`updateLink > link : ${JSON.stringify(link)}`);
+    return link;
   };
-
+  
+  client.setLink(updateLink());
 
   useEffect(() => {
-    client.setLink(ApolloLink.split(
-      (operation) => operation.getContext().clientName === 'country',
-      countryLink,
-      from([withToken, httpLink])
-    ));
-  },[auth]);
+    client.setLink(updateLink());
+  }, [auth]);
 
   return <ApolloProvider client={client}>{props.children}</ApolloProvider>;
 };
-
-export default ApolloConnection;


### PR DESCRIPTION
This pull request refactors the Apollo connection and adds a new removeTypename link. The changes include refactoring the Apollo client setup, adding new Apollo links for authentication and custom headers, and updating the Apollo link chain for different data sources. The code also includes the removal of the `__typename` property from variables.

## Summary by Sourcery

Refactor the Apollo connection by modularizing the Apollo client setup and adding a new link to remove the `__typename` property from variables. This includes the introduction of new Apollo links for authentication and custom headers, and updating the link chain to support different data sources.

New Features:
- Introduce a new Apollo link to remove the `__typename` property from variables, enhancing the flexibility of the Apollo client setup.

Enhancements:
- Refactor the Apollo client setup by modularizing the Apollo links, including links for authentication and custom headers, and updating the link chain for different data sources.