### PR TITLE
Revert custom script for GraphQL code generation

### DIFF
--- a/data-access/package.json
+++ b/data-access/package.json
@@ -12,7 +12,7 @@
     "test": "npx jest --watchAll=true",
     "validate-graphql-schema": "ts-node src/functions/http-graphql/schema/builder/check-duplicate-types.ts",
     "generate-graphql-schema": "graphql-codegen --config src/functions/http-graphql/schema/builder/codegen.yml",
-    "gen": "clear && npm run validate-graphql-schema && npm run generate-graphql-schema",
+    "gen": "graphql-codegen --config src/functions/http-graphql/schema/builder/codegen.yml",
     "gen:watch": "graphql-codegen --config src/functions/http-graphql/schema/builder/codegen.yml --watch  --silent=false",
     "postinstall": "serenity-bdd update",
     "prebdd": "npm run bdd:clean && npm run bdd:build",


### PR DESCRIPTION
Restore the original command for generating GraphQL schemas, removing the custom script that was previously implemented.

## Summary by Sourcery

Build:
- Remove the custom script for GraphQL code generation and restore the original command in the package.json.